### PR TITLE
Disable Fabs on creation

### DIFF
--- a/X1CA_Coop_001/X1CA_Coop_001_script.lua
+++ b/X1CA_Coop_001/X1CA_Coop_001_script.lua
@@ -653,6 +653,12 @@ function IntroNISPart2()
             ScenarioFramework.GiveUnitToArmy( v, Player )
         end
     end
+    
+    -- Turn off those stupid massfabs
+    local massFabs = ArmyBrains[Player]:GetListOfUnits(categories.ueb1303, false)
+    for k, v in massFabs do
+        v:ToggleScriptBit('RULEUTC_ProductionToggle')
+    end
 
     -- Set the gate back to being unkillable
     if ScenarioInfo.NISGate and not ScenarioInfo.NISGate:IsDead() then


### PR DESCRIPTION
This turns off the fabs. It was an absolute PAIN to get this working properly because for some wobegone reason the mission spawns everything as the UEF AI first, then transfers them a section at a time back to the player, creating a whole bunch of new UIDs. This needs merging, but I hope to come back later and see if telling everything to just spawn as the ruddy Player's to begin with will break anything.