### PR TITLE
Cybran M5 not expanding

### DIFF
--- a/SCCA_Coop_R05/SCCA_Coop_R05_script.lua
+++ b/SCCA_Coop_R05/SCCA_Coop_R05_script.lua
@@ -31,6 +31,7 @@ ScenarioInfo.FauxUEF        = 4
 ScenarioInfo.Coop1            = 5
 ScenarioInfo.Coop2            = 6
 ScenarioInfo.Coop3            = 7
+ScenarioInfo.HumanPlayers = {}
 
 local Player                = ScenarioInfo.Player
 local UEF                   = ScenarioInfo.UEF


### PR DESCRIPTION
Table with human players was missing, Map was not expanding after first objective when game tried to remove restrictions from all human players.