### PR TITLE
Aeon M3 Pausing mass fabs

### DIFF
--- a/SCCA_Coop_A03/SCCA_Coop_A03_script.lua
+++ b/SCCA_Coop_A03/SCCA_Coop_A03_script.lua
@@ -292,6 +292,12 @@ function StartMission1()
     platoon.PlatoonData = {}
     platoon.PlatoonData.PatrolChain = 'Navy_Chain'
     ScenarioPlatoonAI.PatrolThread(platoon)
+    
+    -- Turn off massfabs
+    local massFabs = ArmyBrains[Player]:GetListOfUnits(categories.MASSFABRICATION, false)
+    for k, v in massFabs do
+        v:ToggleScriptBit('RULEUTC_ProductionToggle')
+    end
 
     -- After 2 minutes
     ScenarioFramework.CreateTimerTrigger(M1Dialogue1, M1VOTimer1)


### PR DESCRIPTION
pause player's mass fabs at the beginning since they dont consume only 40e as they did in vanilla