### PR TITLE
Easier way to restrict FA units in vanilla

### DIFF
--- a/SCCA_Coop_A02/SCCA_Coop_A02_script.lua
+++ b/SCCA_Coop_A02/SCCA_Coop_A02_script.lua
@@ -296,6 +296,7 @@ function OnStart(self)
          ScenarioFramework.AddRestriction(player, categories.TECH2 +
                                       categories.TECH3 +
                                       categories.EXPERIMENTAL +
+                                      categories.PRODUCTFA + -- All FA Units
                                       categories.uaa0107 ) -- t1 transport
     end
 

--- a/SCCA_Coop_A03/SCCA_Coop_A03_script.lua
+++ b/SCCA_Coop_A03/SCCA_Coop_A03_script.lua
@@ -130,6 +130,7 @@ function OnStart(self)
     for _, player in ScenarioInfo.HumanPlayers do
          ScenarioFramework.AddRestriction(player, ((categories.TECH2 + categories.TECH3) * categories.AEON) +     -- T2 & T3 Aeon
                                      (categories.TECH3 * categories.UEF) +                           -- T3 UEF
+                                     categories.PRODUCTFA +                                          -- All FA Units
                                      categories.uea0204 +                                            -- UEF Torpedo Bomber
                                      categories.uel0203 +                                            -- UEF Amphibious Tank
                                      categories.ues0202)                                             -- UEF Cruiser

--- a/SCCA_Coop_A04/SCCA_Coop_A04_script.lua
+++ b/SCCA_Coop_A04/SCCA_Coop_A04_script.lua
@@ -132,6 +132,7 @@ function OnPopulate(scenario)
     for _, player in ScenarioInfo.HumanPlayers do
          ScenarioFramework.AddRestriction(player, categories.TECH3 +
                                       categories.EXPERIMENTAL +
+                                      categories.PRODUCTFA + -- All FA Units
                                       categories.ual0307 +
                                       categories.uab4201 + categories.urb4201 +
                                       categories.uab4202 + categories.urb4202 +

--- a/SCCA_Coop_A05/SCCA_Coop_A05_script.lua
+++ b/SCCA_Coop_A05/SCCA_Coop_A05_script.lua
@@ -262,6 +262,7 @@ function StartMission1()
     for _, player in ScenarioInfo.HumanPlayers do
          ScenarioFramework.AddRestriction(player, (categories.NAVAL * categories.TECH3) +
                                       categories.EXPERIMENTAL +
+                                      categories.PRODUCTFA + -- All FA Units
      
                                       categories.uab4302 +
                                       categories.uab0301 +

--- a/SCCA_Coop_A06/SCCA_Coop_A06_script.lua
+++ b/SCCA_Coop_A06/SCCA_Coop_A06_script.lua
@@ -367,6 +367,7 @@ function OnStart(self)
                                       categories.ual0401 + -- Giant Assault Bot
                                       categories.uas0401 + -- Submersible Battleship
                                       categories.uas0304 + -- Strategic Missile Submarine
+                                      categories.PRODUCTFA + -- All FA Units
                                       categories.uaa0310 ) -- Death Saucer
     end
 

--- a/SCCA_Coop_E04/SCCA_Coop_E04_script.lua
+++ b/SCCA_Coop_E04/SCCA_Coop_E04_script.lua
@@ -274,6 +274,8 @@ function StartMission1()
         ScenarioFramework.AddRestriction(player, categories.TECH3 - categories.ueb0302 - categories.zeb9602 - categories.urb0302 - categories.zrb9602 -  categories.uea0302 - categories.ura0302)
         -- prevent building t2 restricted units
         ScenarioFramework.AddRestriction(player, M1UEFTech2NotAllowed)
+        -- prevent bulding FA units
+        scenarioframework:AddRestriction(player, categories.PRODUCTFA)
         -- prevent building cybran t2 restricted units, should the player capture cybran engineers
         ScenarioFramework.AddRestriction(player, M1CybranTech2NotAllowed)
     end

--- a/SCCA_Coop_E05/SCCA_Coop_E05_script.lua
+++ b/SCCA_Coop_E05/SCCA_Coop_E05_script.lua
@@ -352,20 +352,7 @@ function OnPopulate(scenario)
                                       categories.ueb2302 + -- Long Range Heavy Artillery
                                       categories.uel0401 + -- Experimental Mobile Factory
                                       categories.ues0304 + -- Strategic Missile Submarine
-                                      categories.dea0202 +  -- UEF Fighter Bomber
-                                      categories.del0204 +  -- UEF Gatling Bot
-                                      categories.xeb2306 +  -- UEF Heavy Point Defense
-                                      categories.xel0305 +  -- UEF Percival
-                                      categories.xel0306 +  -- UEF Mobile Missile Platform
-                                      categories.xes0102 +  -- UEF Torpedo Boat
-                                      categories.xes0205 +  -- UEF Shield Boat
-                                      categories.xes0307 +  -- UEF Battlecruiser
-                                      categories.xeb0104 +  -- UEF Engineering Station 1
-                                      categories.xeb0204 +  -- UEF Engineering Station 2
-                                      categories.xel0209 +  -- UEF Sparky
-                                      categories.xea0306 +  -- UEF Heavy Air Transport
-                                      categories.xeb2402 +  -- UEF Sub-Orbital Defense System
-                                      categories.delk002 +  -- UEF T3 Mobile AA
+                                      categories.delk002 + -- UEF T3 Mobile AA
      
                                       categories.uab4302 + -- Strategic Missile Defense
                                       categories.uab0304 + -- Quantum Gateway
@@ -378,18 +365,6 @@ function OnPopulate(scenario)
                                       categories.uas0305 + -- T3 Mobile Sonar
                                       categories.uab2302 + -- Long Range Heavy Artillery
                                       categories.uas0304 + -- Strategic Missile Submarine
-                                      categories.xal0305 + -- Aeon Sniper Bot
-                                      categories.xaa0202 + -- Aeon Mid Range fighter (Swift Wind)
-                                      categories.daa0206 + -- Aeon Mercy
-                                      categories.dal0310 + -- Aeon Shield Disruptor
-                                      categories.xal0203 + -- Aeon Assault Tank (Blaze)
-                                      categories.xab1401 + -- Aeon Quantum Resource Generator
-                                      categories.xas0204 + -- Aeon Submarine Hunter
-                                      categories.xaa0306 + -- Aeon Torpedo Bomber
-                                      categories.xas0306 + -- Aeon Missile Ship
-                                      categories.xab3301 + -- Aeon Quantum Optics Device
-                                      categories.xab2307 + -- Aeon Rapid Fire Artillery
-                                      categories.xaa0305 + -- Aeon AA Gunship
                                       categories.dalk003 + -- Aeon M3 Mobile AA
      
                                       categories.urb4302 + -- Strategic Missile Defense
@@ -406,20 +381,9 @@ function OnPopulate(scenario)
                                       categories.drlk001 + -- Cybran T3 Mobile AA
                                       categories.delk002 + -- UEF T3 Mobile AA
                                       categories.dalk003 + -- Aeon M3 Mobile AA
-                                      categories.xrl0302 + -- Cybran Mobile Bomb
-                                      categories.xra0105 + -- Cybran Light Gunship
-                                      categories.xrs0204 + -- Cybran Sub Killer
-                                      categories.xrs0205 + -- Cybran Counter-Intelligence Boat
-                                      categories.xrb2308 + -- Cybran Torpedo Ambushing System
-                                      categories.xrb0104 + -- Cybran Engineering Station 1
-                                      categories.xrb0204 + -- Cybran Engineering Station 2
-                                      categories.xrb0304 + -- Cybran Engineering Station 3
-                                      categories.xrb3301 + -- Cybran Perimeter Monitoring System
-                                      categories.xra0305 + -- Cybran Heavy Gunship
-                                      categories.xrl0305 + -- Cybran Brick
-                                      categories.dra0202 + -- Cybran FIghter Bomber
-                                      categories.drl0204 + -- Cybran Rocket Bot
                                       categories.drlk001 + -- Cybran T3 Mobile AA
+
+                                      categories.PRODUCTFA + -- All FA Units
      
                                       categories.EXPERIMENTAL )
     end

--- a/SCCA_Coop_E06/SCCA_Coop_E06_script.lua
+++ b/SCCA_Coop_E06/SCCA_Coop_E06_script.lua
@@ -252,49 +252,10 @@ function OnPopulate(scen)
          ScenarioFramework.AddRestriction(player, categories.EXPERIMENTAL +
                                       categories.ueb2302 +  -- UEF T3 Artillery
                                       categories.ueb4301 +  -- UEF T3 Heavy Shield
-                                      categories.dea0202 +  -- UEF Fighter Bomber
-                                      categories.del0204 +  -- UEF Gatling Bot
-                                      categories.xeb2306 +  -- UEF Heavy Point Defense
-                                      categories.xel0305 +  -- UEF Percival
-                                      categories.xel0306 +  -- UEF Mobile Missile Platform
-                                      categories.xes0102 +  -- UEF Torpedo Boat
-                                      categories.xes0205 +  -- UEF Shield Boat
-                                      categories.xes0307 +  -- UEF Battlecruiser
-                                      categories.xeb0104 +  -- UEF Engineering Station 1
-                                      categories.xeb0204 +  -- UEF Engineering Station 2
-                                      categories.xel0209 +  -- UEF Sparky
-                                      categories.xea0306 +  -- UEF Heavy Air Transport
-                                      categories.xeb2402 +  -- UEF Sub-Orbital Defense System
                                       categories.delk002 +  -- UEF T3 Mobile AA
-
-                                      categories.xal0305 + -- Aeon Sniper Bot
-                                      categories.xaa0202 + -- Aeon Mid Range fighter (Swift Wind)
-                                      categories.daa0206 + -- Aeon Mercy
-                                      categories.dal0310 + -- Aeon Shield Disruptor
-                                      categories.xal0203 + -- Aeon Assault Tank (Blaze)
-                                      categories.xab1401 + -- Aeon Quantum Resource Generator
-                                      categories.xas0204 + -- Aeon Submarine Hunter
-                                      categories.xaa0306 + -- Aeon Torpedo Bomber
-                                      categories.xas0306 + -- Aeon Missile Ship
-                                      categories.xab3301 + -- Aeon Quantum Optics Device
-                                      categories.xab2307 + -- Aeon Rapid Fire Artillery
-                                      categories.xaa0305 + -- Aeon AA Gunship
                                       categories.dalk003 + -- Aeon M3 Mobile AA
-
-                                      categories.xrl0302 + -- Cybran Mobile Bomb
-                                      categories.xra0105 + -- Cybran Light Gunship
-                                      categories.xrs0204 + -- Cybran Sub Killer
-                                      categories.xrs0205 + -- Cybran Counter-Intelligence Boat
-                                      categories.xrb2308 + -- Cybran Torpedo Ambushing System
-                                      categories.xrb0104 + -- Cybran Engineering Station 1
-                                      categories.xrb0204 + -- Cybran Engineering Station 2
-                                      categories.xrb0304 + -- Cybran Engineering Station 3
-                                      categories.xrb3301 + -- Cybran Perimeter Monitoring System
-                                      categories.xra0305 + -- Cybran Heavy Gunship
-                                      categories.xrl0305 + -- Cybran Brick
-                                      categories.dra0202 + -- Cybran FIghter Bomber
-                                      categories.drl0204 + -- Cybran Rocket Bot
                                       categories.drlk001 + -- Cybran T3 Mobile AA
+                                      categories.PRODUCTFA + --All FA Units
                                       categories.ues0304 ) -- UEF T3 Strategic Missile Submarine
     end
 

--- a/SCCA_Coop_R02/SCCA_Coop_R02_script.lua
+++ b/SCCA_Coop_R02/SCCA_Coop_R02_script.lua
@@ -648,9 +648,9 @@ function TrackIntialJanusThread(unit)
 end
 
 function M1GiveTech()
-    -- No one should be able to build any T3 units
+    -- No one should be able to build any T3 units and FA Units
     for _, player in ScenarioInfo.HumanPlayers do
-         ScenarioFramework.AddRestriction(player, categories.TECH3)
+         ScenarioFramework.AddRestriction(player, categories.TECH3 + categories.PRODUCTFA)
     end
     ScenarioFramework.AddRestriction(CybranJanus, categories.TECH3)
     ScenarioFramework.AddRestriction(Aeon, categories.TECH3)

--- a/SCCA_Coop_R03/SCCA_Coop_R03_script.lua
+++ b/SCCA_Coop_R03/SCCA_Coop_R03_script.lua
@@ -573,9 +573,9 @@ function M3P1Reminder3()
 end
 
 function GiveMission1Tech()
-    -- No one should be able to build any T3 units
+    -- No one should be able to build any T3 units and FA Units
     for _, player in ScenarioInfo.HumanPlayers do
-         ScenarioFramework.AddRestriction(player, categories.TECH3)
+         ScenarioFramework.AddRestriction(player, categories.TECH3 + categories.PRODUCTFA)
     end
     ScenarioFramework.AddRestriction(UEF, categories.TECH3)
     -- Most T2 units are not buildable at the start of this mission

--- a/SCCA_Coop_R04/SCCA_Coop_R04_script.lua
+++ b/SCCA_Coop_R04/SCCA_Coop_R04_script.lua
@@ -494,6 +494,7 @@ function OnStart(self)
         for iArmy, strArmy in pairs(tblArmy) do
             if iArmy == player then
                 ScenarioFramework.AddRestriction(player,
+                    categories.PRODUCTFA + -- ALl FA Units
                     categories.TECH3 +  -- All T3 units
                     categories.EXPERIMENTAL + -- All experimental units
                     categories.urb4202 + -- T2 Shield Generator
@@ -508,27 +509,6 @@ function OnStart(self)
                     categories.url0306 + -- Mobile Stealth Generator
                     categories.urs0202 + -- Cruiser
                     categories.urb5202 + -- Air Staging Platform
-                    categories.xrl0302 + -- Cybran Mobile Bomb
-                    categories.xra0105 + -- Cybran Light Gunship
-                    categories.xrs0204 + -- Cybran Sub Killer
-                    categories.xrs0205 + -- Cybran Counter-Intelligence Boat
-                    categories.xrb0104 + -- Cybran Engineering Station 1
-                    categories.xrb0204 + -- Cybran Engineering Station 2
-                    categories.xrb0304 + -- Cybran Engineering Station 3
-                    categories.dra0202 + -- Cybran FIghter Bomber
-                    categories.drl0204 + -- Cybran Rocket Bot
-                    categories.xal0305 + -- Aeon Sniper Bot
-                    categories.xaa0202 + -- Aeon Mid Range fighter (Swift Wind)
-                    categories.xal0203 + -- Aeon Assault Tank (Blaze)
-                    categories.xab1401 + -- Aeon Quantum Resource Generator
-                    categories.xas0204 + -- Aeon Submarine Hunter
-                    categories.xaa0306 + -- Aeon Torpedo Bomber
-                    categories.xas0306 + -- Aeon Missile Ship
-                    categories.xab3301 + -- Aeon Quantum Optics Device
-                    categories.xab2307 + -- Aeon Rapid Fire Artillery
-                    categories.xaa0305 + -- Aeon AA Gunship
-                    categories.daa0206 + -- Aeon Mercy
-                    categories.dal0310 + -- Aeon Shield Disruptor
                     categories.urb4201 ) -- T2 Anti-Missile Gun
 
                 ScenarioFramework.RestrictEnhancements({'StealthGenerator',

--- a/SCCA_Coop_R05/SCCA_Coop_R05_script.lua
+++ b/SCCA_Coop_R05/SCCA_Coop_R05_script.lua
@@ -1512,6 +1512,7 @@ function M1_BuildCategories()
         for iArmy, strArmy in pairs(tblArmy) do
             if iArmy == player then
                 ScenarioFramework.AddRestriction(player,
+                         categories.PRODUCTFA + -- All FA Units
                          categories.urb0303 + -- T3 Naval Factory
                          categories.urb2302 + -- Long Range Heavy Artillery
                          categories.url0301 + -- Sub Commander
@@ -1525,21 +1526,6 @@ function M1_BuildCategories()
                          categories.urs0304 + -- Strategic Missile Submarine
                          categories.ura0401 + -- Exp. T4 gunship
                          categories.urb4207 + -- Final T2 Shield upgrade
-
-                         categories.xrl0302 + -- Cybran Mobile Bomb
-                         categories.xra0105 + -- Cybran Light Gunship
-                         categories.xrs0204 + -- Cybran Sub Killer
-                         categories.xrs0205 + -- Cybran Counter-Intelligence Boat
-                         categories.xrb2308 + -- Cybran Torpedo Ambushing System
-                         categories.xrb0104 + -- Cybran Engineering Station 1
-                         categories.xrb0204 + -- Cybran Engineering Station 2
-                         categories.xrb0304 + -- Cybran Engineering Station 3
-                         categories.xrb3301 + -- Cybran Perimeter Monitoring System
-                         categories.xra0305 + -- Cybran Heavy Gunship
-                         categories.xrl0305 + -- Cybran Brick
-                         categories.xrl0403 + -- Cybran Amphibious Mega Bot
-                         categories.dra0202 + -- Cybran FIghter Bomber
-                         categories.drl0204 + -- Cybran Rocket Bot
                          categories.drlk001 + -- Cybran T3 Mobile AA
 
                          categories.ueb0302 + -- T3 Naval Factory
@@ -1551,20 +1537,6 @@ function M1_BuildCategories()
                          categories.ueb4302 + -- T3 Strategic Missile Defense
                          categories.ueb2305 + -- Strategic Missile Launcher
                          categories.ues0304 + -- Strategic Missile Submarine
-
-                         categories.xeb2306 + -- UEF Heavy Point Defense
-                         categories.xel0305 + -- UEF Percival
-                         categories.xel0306 + -- UEF Mobile Missile Platform
-                         categories.xes0102 + -- UEF Torpedo Boat
-                         categories.xes0205 + -- UEF Shield Boat
-                         categories.xes0307 + -- UEF Battlecruiser
-                         categories.xeb0104 + -- UEF Engineering Station 1
-                         categories.xeb0204 + -- UEF Engineering Station 2
-                         categories.xea0306 + -- UEF Heavy Air Transport
-                         categories.xeb2402 + -- UEF Sub-Orbital Defense System
-                         categories.dea0202 + -- UEF Fighter Bomber
-                         categories.del0204 + -- UEF Gatling Bot
-                         categories.xel0209 + -- UEF Sparky
                          categories.delk002 + -- UEF T3 Mobile AA
 
                          categories.urb2108 + -- Tactical Missile Launcher

--- a/SCCA_Coop_R06/SCCA_Coop_R06_script.lua
+++ b/SCCA_Coop_R06/SCCA_Coop_R06_script.lua
@@ -285,59 +285,21 @@ function OnStart(self)
         for iArmy, strArmy in pairs(tblArmy) do
             if iArmy == player then
                 ScenarioFramework.AddRestriction(player,
+                    categories.PRODUCTFA + -- All FA Units
                     categories.urb2305 +   -- Strategic Missile Launcher
                     categories.urb4302 +   -- Strategic Missile Defense
                     categories.url0402 +   -- Spider Bot
                     categories.urs0304 +   -- Strategic Missile Submarine
-                    categories.xrl0302 +   -- Cybran Mobile Bomb
-                    categories.xra0105 +   -- Cybran Light Gunship
-                    categories.xrs0204 +   -- Cybran Sub Killer
-                    categories.xrs0205 +   -- Cybran Counter-Intelligence Boat
-                    categories.xrb2308 +   -- Cybran Torpedo Ambushing System
-                    categories.xrb0104 +   -- Cybran Engineering Station 1
-                    categories.xrb0204 +   -- Cybran Engineering Station 2
-                    categories.xrb0304 +   -- Cybran Engineering Station 3
-                    categories.xrb3301 +   -- Cybran Perimeter Monitoring System
-                    categories.xra0305 +   -- Cybran Heavy Gunship
-                    categories.xrl0305 +   -- Cybran Brick
-                    categories.dra0202 +   -- Cybran FIghter Bomber
-                    categories.drl0204 +   -- Cybran Rocket Bot
                     categories.drlk001 +   -- Cybran T3 Mobile AA
-                    categories.xrl0403 +   -- Cybran Amphibious Mega Bot
 
                     categories.ueb2302 +  -- Long Range Heavy Artillery
                     categories.ueb4301 +  -- T3 Heavy Shield Generator
                     categories.uel0401 +  -- Experimental Mobile Factory
-                    categories.dea0202 +  -- UEF Fighter Bomber
-                    categories.del0204 +  -- UEF Gatling Bot
-                    categories.xeb2306 +  -- UEF Heavy Point Defense
-                    categories.xel0305 +  -- UEF Percival
-                    categories.xel0306 +  -- UEF Mobile Missile Platform
-                    categories.xes0102 +  -- UEF Torpedo Boat
-                    categories.xes0205 +  -- UEF Shield Boat
-                    categories.xes0307 +  -- UEF Battlecruiser
-                    categories.xeb0104 +  -- UEF Engineering Station 1
-                    categories.xeb0204 +  -- UEF Engineering Station 2
-                    categories.xel0209 +  -- UEF Sparky
-                    categories.xea0306 +  -- UEF Heavy Air Transport
-                    categories.xeb2402 +  -- UEF Sub-Orbital Defense System
                     categories.delk002 +  -- UEF T3 Mobile AA
                     categories.ues0304 +  -- Strategic Missile Submarine
 
                     categories.uab0304 + -- Quantum Gate
                     categories.ual0301 + -- Sub Commander
-                    categories.xal0305 + -- Aeon Sniper Bot
-                    categories.xaa0202 + -- Aeon Mid Range fighter (Swift Wind)
-                    categories.daa0206 + -- Aeon Mercy
-                    categories.dal0310 + -- Aeon Shield Disruptor
-                    categories.xal0203 + -- Aeon Assault Tank (Blaze)
-                    categories.xab1401 + -- Aeon Quantum Resource Generator
-                    categories.xas0204 + -- Aeon Submarine Hunter
-                    categories.xaa0306 + -- Aeon Torpedo Bomber
-                    categories.xas0306 + -- Aeon Missile Ship
-                    categories.xab3301 + -- Aeon Quantum Optics Device
-                    categories.xab2307 + -- Aeon Rapid Fire Artillery
-                    categories.xaa0305 + -- Aeon AA Gunship
                     categories.dalk003 + -- Aeon M3 Mobile AA
                     categories.uas0304)  -- Strategic Missile Submarine
             end


### PR DESCRIPTION
Redone restrictions for Cybran and UEF campaign and added them for Aeon campaign as well. Better way than in #54 

And fixes  part of #53