### PR TITLE
Re-add Debug Option for Skipping Cinematics

### DIFF
--- a/X1CA_Coop_002/X1CA_Coop_002_script.lua
+++ b/X1CA_Coop_002/X1CA_Coop_002_script.lua
@@ -62,6 +62,13 @@ local Difficulty = ScenarioInfo.Options.Difficulty
 
 ScenarioInfo.HumanPlayers = {}
 
+-- -----------
+-- Debug only!
+-- -----------
+local SkipNIS2 = false
+local SkipM3Dialog = false
+local DebugShortM3 = false
+
 ----------------
 -- Taunt Managers
 ----------------
@@ -757,57 +764,59 @@ end
 function IntroMission2NIS()
     ScenarioFramework.SetPlayableArea('M2_Playable_Area', false)
 
-    Cinematics.EnterNISMode()
-    Cinematics.SetInvincible('M1_Playable_Area')
+    if ( not SkipNIS2 ) then
+        Cinematics.EnterNISMode()
+        Cinematics.SetInvincible('M1_Playable_Area')
 
-    local fakeMarker1 = {
-        ['zoom'] = FLOAT(35),
-        ['canSetCamera'] = BOOLEAN(true),
-        ['canSyncCamera'] = BOOLEAN(true),
-        ['color'] = STRING('ff808000'),
-        ['editorIcon'] = STRING('/textures/editor/marker_mass.bmp'),
-        ['type'] = STRING('Camera Info'),
-        ['prop'] = STRING('/env/common/props/markers/M_Camera_prop.bp'),
-        ['orientation'] = VECTOR3(-3.14159, 1.19772, 0),
-        ['position'] = ScenarioInfo.PlayerCDR:GetPosition(),
-    }
-    Cinematics.CameraMoveToMarker(fakeMarker1, 0)
+        local fakeMarker1 = {
+            ['zoom'] = FLOAT(35),
+            ['canSetCamera'] = BOOLEAN(true),
+            ['canSyncCamera'] = BOOLEAN(true),
+            ['color'] = STRING('ff808000'),
+            ['editorIcon'] = STRING('/textures/editor/marker_mass.bmp'),
+            ['type'] = STRING('Camera Info'),
+            ['prop'] = STRING('/env/common/props/markers/M_Camera_prop.bp'),
+            ['orientation'] = VECTOR3(-3.14159, 1.19772, 0),
+            ['position'] = ScenarioInfo.PlayerCDR:GetPosition(),
+        }
+        Cinematics.CameraMoveToMarker(fakeMarker1, 0)
 
-    WaitSeconds(1)
+        WaitSeconds(1)
 
-    -- Show the prison
-    ScenarioFramework.CreateVisibleAreaLocation(4, ScenarioInfo.Prison:GetPosition(), 10, ArmyBrains[Player])
-    ScenarioFramework.CreateVisibleAreaLocation(60, ScenarioUtils.MarkerToPosition('M2_QAI_Base_Marker'), 10, ArmyBrains[Player])
-    -- ScenarioFramework.CreateVisibleAreaLocation( 60, ScenarioUtils.MarkerToPosition( 'Order_M2_North_Base_Marker' ), 10, ArmyBrains[Player] )
-    ScenarioFramework.CreateVisibleAreaLocation(350, ScenarioInfo.Prison:GetPosition(), 1, ArmyBrains[Player])
+        -- Show the prison
+        ScenarioFramework.CreateVisibleAreaLocation(4, ScenarioInfo.Prison:GetPosition(), 10, ArmyBrains[Player])
+        ScenarioFramework.CreateVisibleAreaLocation(60, ScenarioUtils.MarkerToPosition('M2_QAI_Base_Marker'), 10, ArmyBrains[Player])
+        -- ScenarioFramework.CreateVisibleAreaLocation( 60, ScenarioUtils.MarkerToPosition( 'Order_M2_North_Base_Marker' ), 10, ArmyBrains[Player] )
+        ScenarioFramework.CreateVisibleAreaLocation(350, ScenarioInfo.Prison:GetPosition(), 1, ArmyBrains[Player])
 
-    WaitSeconds(1)
-    ScenarioFramework.Dialogue(OpStrings.X02_M02_010, nil, true)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_1'), 3)
-    WaitSeconds(1)
+        WaitSeconds(1)
+        ScenarioFramework.Dialogue(OpStrings.X02_M02_010, nil, true)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_1'), 3)
+        WaitSeconds(1)
 
-    ScenarioFramework.Dialogue(OpStrings.X02_M02_011, nil, true)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_2'), 3)
-    WaitSeconds(1)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_3'), 4)
-    WaitSeconds(1)
+        ScenarioFramework.Dialogue(OpStrings.X02_M02_011, nil, true)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_2'), 3)
+        WaitSeconds(1)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_3'), 4)
+        WaitSeconds(1)
 
-    ScenarioFramework.Dialogue(OpStrings.X02_M02_012, nil, true)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_4'), 4)
-    WaitSeconds(1)
+        ScenarioFramework.Dialogue(OpStrings.X02_M02_012, nil, true)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_4'), 4)
+        WaitSeconds(1)
 
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_5'), 4)
-    -- WaitSeconds(1)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_5'), 4)
+        -- WaitSeconds(1)
 
-    ScenarioFramework.Dialogue(OpStrings.X02_M02_013, nil, true)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_6'), 5)
-    WaitSeconds(1)
+        ScenarioFramework.Dialogue(OpStrings.X02_M02_013, nil, true)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_6'), 5)
+        WaitSeconds(1)
 
-    ScenarioFramework.Dialogue(OpStrings.X02_M02_014, nil, true)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_7'), 3)
+        ScenarioFramework.Dialogue(OpStrings.X02_M02_014, nil, true)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_7'), 3)
 
-    Cinematics.SetInvincible('M1_Playable_Area', true)
-    Cinematics.ExitNISMode()
+        Cinematics.SetInvincible('M1_Playable_Area', true)
+        Cinematics.ExitNISMode()
+    end
 
     StartMission2()
 end
@@ -1071,19 +1080,25 @@ function StartMission3()
     )
     table.insert(AssignedObjectives, ScenarioInfo.M3P1)
 
-    ScenarioFramework.CreateTimerTrigger(M3PrincessReveal, 60)
+    if ( not DebugShortM3 ) then
+        ScenarioFramework.CreateTimerTrigger(M3PrincessReveal, 60)
+    else
+        ScenarioFramework.CreateTimerTrigger(M3PrincessReveal, 5)
+    end
 
     -- In case any dialogue is queueing up, turn off Celenes taunt manager early, ahead of the flip.
     CeleneTM:Activate(false)
 end
 
 function M3PrincessReveal()
-    ScenarioFramework.Dialogue(OpStrings.X02_M02_170)
-    ScenarioFramework.Dialogue(OpStrings.X02_M02_171)
-    ScenarioFramework.Dialogue(OpStrings.X02_M02_172)
-    ScenarioFramework.Dialogue(OpStrings.X02_M02_173)
-    ScenarioFramework.Dialogue(OpStrings.X02_M02_174)
-    ScenarioFramework.Dialogue(OpStrings.X02_M02_175)
+    if ( not SkipM3Dialog ) then
+        ScenarioFramework.Dialogue(OpStrings.X02_M02_170)
+        ScenarioFramework.Dialogue(OpStrings.X02_M02_171)
+        ScenarioFramework.Dialogue(OpStrings.X02_M02_172)
+        ScenarioFramework.Dialogue(OpStrings.X02_M02_173)
+        ScenarioFramework.Dialogue(OpStrings.X02_M02_174)
+        ScenarioFramework.Dialogue(OpStrings.X02_M02_175)
+    end
     ScenarioFramework.Dialogue(OpStrings.X02_M02_176, EndMission3)
 end
 

--- a/X1CA_Coop_003/X1CA_Coop_003_script.lua
+++ b/X1CA_Coop_003/X1CA_Coop_003_script.lua
@@ -60,6 +60,12 @@ local NumBombers = 0
 -- How long should we wait at the beginning of the NIS to allow slower machines to catch up?
 local NIS1InitialDelay = 1
 
+-------------
+-- Debug only!
+-------------
+local SkipNIS1 = false
+local SkipNIS2 = false
+
 ----------------
 -- Taunt Managers
 ----------------
@@ -295,7 +301,9 @@ function OnStart()
 
     ScenarioFramework.AddRestriction(Rhiza, categories.uas0302) -- Aeon Battleship
 
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1'), 0)
+    if not SkipNIS1 then
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1'), 0)
+    end
 
     ForkThread(IntroNIS)
 end
@@ -368,130 +376,169 @@ function IntroNIS()
     -- Show the north base buildings
     local NorthVisMarker = ScenarioFramework.CreateVisibleAreaLocation( 100, ScenarioUtils.MarkerToPosition( 'M1_North_Vis_Marker' ), 0, ArmyBrains[Player] )
 
-    Cinematics.EnterNISMode()
+    if not SkipNIS1 then
+        Cinematics.EnterNISMode()
 
-    -- I'm not sure that the player can really see these ships much with the current pan speed we're using
-    -- So, commenting out for now
-    -- local VisMarker = ScenarioFramework.CreateVisibleAreaLocation(30, ScenarioUtils.MarkerToPosition('NIS1_VisMarker'), 25, ArmyBrains[Player])
+        -- I'm not sure that the player can really see these ships much with the current pan speed we're using
+        -- So, commenting out for now
+        -- local VisMarker = ScenarioFramework.CreateVisibleAreaLocation(30, ScenarioUtils.MarkerToPosition('NIS1_VisMarker'), 25, ArmyBrains[Player])
 
-    -- Turn off her shields for more visibility during the NIS
-    local AllShieldUnits = ArmyBrains[Rhiza]:GetListOfUnits(categories.SHIELD, false)
-    ForkThread(ShieldToggle, AllShieldUnits, false, false)
+        -- Turn off her shields for more visibility during the NIS
+        local AllShieldUnits = ArmyBrains[Rhiza]:GetListOfUnits(categories.SHIELD, false)
+        ForkThread(ShieldToggle, AllShieldUnits, false, false)
 
 
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1'), 0)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1'), 0)
 
-    -- Let slower machines catch up before we get going
-    WaitSeconds(NIS1InitialDelay)
+        -- Let slower machines catch up before we get going
+        WaitSeconds(NIS1InitialDelay)
 
-    ScenarioFramework.Dialogue(OpStrings.X03_M01_010, nil, true)
+        ScenarioFramework.Dialogue(OpStrings.X03_M01_010, nil, true)
 
-    WaitSeconds(2)
+        WaitSeconds(2)
 
-    local NISUnits1 = ScenarioUtils.CreateArmyGroup('Seraphim', 'Initial_NIS')
-    local NISUnits2 = ScenarioUtils.CreateArmyGroup('Rhiza', 'Initial_NIS')
+        local NISUnits1 = ScenarioUtils.CreateArmyGroup('Seraphim', 'Initial_NIS')
+        local NISUnits2 = ScenarioUtils.CreateArmyGroup('Rhiza', 'Initial_NIS')
 
-    WaitSeconds(1)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_2'), 4)
-    WaitSeconds(0.5)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_3'), 2)
-    WaitSeconds(0.5)
+        WaitSeconds(1)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_2'), 4)
+        WaitSeconds(0.5)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_3'), 2)
+        WaitSeconds(0.5)
 
-    if (LeaderFaction == 'uef') then
-        ScenarioFramework.Dialogue(OpStrings.X03_M01_020, nil, true)
-        ScenarioFramework.Dialogue(OpStrings.X03_M01_021, nil, true)
-    elseif (LeaderFaction == 'cybran') then
-        ScenarioFramework.Dialogue(OpStrings.X03_M01_030, nil, true)
-        ScenarioFramework.Dialogue(OpStrings.X03_M01_031, nil, true)
-    elseif (LeaderFaction == 'aeon') then
-        ScenarioFramework.Dialogue(OpStrings.X03_M01_040, nil, true)
-        ScenarioFramework.Dialogue(OpStrings.X03_M01_041, nil, true)
-    end
+        if (LeaderFaction == 'uef') then
+            ScenarioFramework.Dialogue(OpStrings.X03_M01_020, nil, true)
+            ScenarioFramework.Dialogue(OpStrings.X03_M01_021, nil, true)
+        elseif (LeaderFaction == 'cybran') then
+            ScenarioFramework.Dialogue(OpStrings.X03_M01_030, nil, true)
+            ScenarioFramework.Dialogue(OpStrings.X03_M01_031, nil, true)
+        elseif (LeaderFaction == 'aeon') then
+            ScenarioFramework.Dialogue(OpStrings.X03_M01_040, nil, true)
+            ScenarioFramework.Dialogue(OpStrings.X03_M01_041, nil, true)
+        end
 
-    if (Difficulty == 3) then
-        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_4_Hard'), 3)
-    else
-        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_4'), 3)
-    end
-    WaitSeconds(1)
-    if (Difficulty == 3) then
-        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_5_Hard'), 6)
-    else
-        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_5'), 6)
-    end
-    WaitSeconds(1)
+        if (Difficulty == 3) then
+            Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_4_Hard'), 3)
+        else
+            Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_4'), 3)
+        end
+        WaitSeconds(1)
+        if (Difficulty == 3) then
+            Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_5_Hard'), 6)
+        else
+            Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_5'), 6)
+        end
+        WaitSeconds(1)
 
-    -- Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1_2'), 0)
-    -- Cinematics.CameraTrackEntity( ScenarioInfo.RhizaACU, 20, 0 )
-    Cinematics.CameraTrackEntity(ScenarioInfo.RhizaACU, 30, 4)
-    WaitSeconds(1.5)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_6'), 3)
+        -- Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1_2'), 0)
+        -- Cinematics.CameraTrackEntity( ScenarioInfo.RhizaACU, 20, 0 )
+        Cinematics.CameraTrackEntity(ScenarioInfo.RhizaACU, 30, 4)
+        WaitSeconds(1.5)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_6'), 3)
 
-    if (LeaderFaction == 'aeon') then
-        ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'AeonPlayer')
-    elseif (LeaderFaction == 'uef') then
-        ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'UEFPlayer')
-    elseif (LeaderFaction == 'cybran') then
-        ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'CybranPlayer')
-    end
+        if (LeaderFaction == 'aeon') then
+            ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'AeonPlayer')
+        elseif (LeaderFaction == 'uef') then
+            ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'UEFPlayer')
+        elseif (LeaderFaction == 'cybran') then
+            ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'CybranPlayer')
+        end
 
-    ScenarioInfo.PlayerCDR:PlayCommanderWarpInEffect()
-    ScenarioFramework.PauseUnitDeath(ScenarioInfo.PlayerCDR)
-    ScenarioFramework.CreateUnitDeathTrigger(PlayerDeath, ScenarioInfo.PlayerCDR)
+        ScenarioInfo.PlayerCDR:PlayCommanderWarpInEffect()
+        ScenarioFramework.PauseUnitDeath(ScenarioInfo.PlayerCDR)
+        ScenarioFramework.CreateUnitDeathTrigger(PlayerDeath, ScenarioInfo.PlayerCDR)
 
-    -- spawn coop players too
-    ScenarioInfo.CoopCDR = {}
-    local tblArmy = ListArmies()
-    coop = 1
-    for iArmy, strArmy in pairs(tblArmy) do
-        if iArmy >= ScenarioInfo.Coop1 then
-            factionIdx = GetArmyBrain(strArmy):GetFactionIndex()
-            if (factionIdx == 1) then
-                ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'UEFPlayer')
-            elseif (factionIdx == 2) then
-                ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'AeonPlayer')
-            else
-                ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'CybranPlayer')
+        -- spawn coop players too
+        ScenarioInfo.CoopCDR = {}
+        local tblArmy = ListArmies()
+        coop = 1
+        for iArmy, strArmy in pairs(tblArmy) do
+            if iArmy >= ScenarioInfo.Coop1 then
+                factionIdx = GetArmyBrain(strArmy):GetFactionIndex()
+                if (factionIdx == 1) then
+                    ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'UEFPlayer')
+                elseif (factionIdx == 2) then
+                    ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'AeonPlayer')
+                else
+                    ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'CybranPlayer')
+                end
+                ScenarioInfo.CoopCDR[coop]:PlayCommanderWarpInEffect()
+                coop = coop + 1
+                WaitSeconds(0.5)
             end
-            ScenarioInfo.CoopCDR[coop]:PlayCommanderWarpInEffect()
-            coop = coop + 1
-            WaitSeconds(0.5)
+        end
+
+        for index, coopACU in ScenarioInfo.CoopCDR do
+            ScenarioFramework.PauseUnitDeath(coopACU)
+            ScenarioFramework.CreateUnitDeathTrigger(PlayerDeath, coopACU)
+        end
+
+        WaitSeconds(2)
+
+        if (LeaderFaction == 'aeon') then
+            ScenarioFramework.Dialogue(OpStrings.X03_M01_042, nil, true)
+        elseif (LeaderFaction == 'uef') then
+            ScenarioFramework.Dialogue(OpStrings.X03_M01_022, nil, true)
+        elseif (LeaderFaction == 'cybran') then
+            ScenarioFramework.Dialogue(OpStrings.X03_M01_032, nil, true)
+        end
+
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_7'), 3)
+
+        for k, unit in NISUnits1 do
+            if unit and not unit:IsDead() then
+                unit:Kill()
+            end
+        end
+
+        for k, unit in NISUnits2 do
+            if unit and not unit:IsDead() then
+                unit:Kill()
+            end
+        end
+
+        -- Turn her shields back on
+        ForkThread(ShieldToggle, AllShieldUnits, true, false)
+
+        Cinematics.ExitNISMode()
+    else
+        if (LeaderFaction == 'aeon') then
+            ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'AeonPlayer')
+        elseif (LeaderFaction == 'uef') then
+            ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'UEFPlayer')
+        elseif (LeaderFaction == 'cybran') then
+            ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'CybranPlayer')
+        end
+
+        ScenarioInfo.PlayerCDR:PlayCommanderWarpInEffect()
+        ScenarioFramework.PauseUnitDeath(ScenarioInfo.PlayerCDR)
+        ScenarioFramework.CreateUnitDeathTrigger(PlayerDeath, ScenarioInfo.PlayerCDR)
+
+        -- spawn coop players too
+        ScenarioInfo.CoopCDR = {}
+        local tblArmy = ListArmies()
+        coop = 1
+        for iArmy, strArmy in pairs(tblArmy) do
+            if iArmy >= ScenarioInfo.Coop1 then
+                factionIdx = GetArmyBrain(strArmy):GetFactionIndex()
+                if (factionIdx == 1) then
+                    ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'UEFPlayer')
+                elseif (factionIdx == 2) then
+                    ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'AeonPlayer')
+                else
+                    ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'CybranPlayer')
+                end
+                ScenarioInfo.CoopCDR[coop]:PlayCommanderWarpInEffect()
+                coop = coop + 1
+                WaitSeconds(0.5)
+            end
+        end
+
+        for index, coopACU in ScenarioInfo.CoopCDR do
+            ScenarioFramework.PauseUnitDeath(coopACU)
+            ScenarioFramework.CreateUnitDeathTrigger(PlayerDeath, coopACU)
         end
     end
-
-    for index, coopACU in ScenarioInfo.CoopCDR do
-        ScenarioFramework.PauseUnitDeath(coopACU)
-        ScenarioFramework.CreateUnitDeathTrigger(PlayerDeath, coopACU)
-    end
-
-    WaitSeconds(2)
-
-    if (LeaderFaction == 'aeon') then
-        ScenarioFramework.Dialogue(OpStrings.X03_M01_042, nil, true)
-    elseif (LeaderFaction == 'uef') then
-        ScenarioFramework.Dialogue(OpStrings.X03_M01_022, nil, true)
-    elseif (LeaderFaction == 'cybran') then
-        ScenarioFramework.Dialogue(OpStrings.X03_M01_032, nil, true)
-    end
-
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_7'), 3)
-
-    for k, unit in NISUnits1 do
-        if unit and not unit:IsDead() then
-            unit:Kill()
-        end
-    end
-
-    for k, unit in NISUnits2 do
-        if unit and not unit:IsDead() then
-            unit:Kill()
-        end
-    end
-
-    -- Turn her shields back on
-    ForkThread(ShieldToggle, AllShieldUnits, true, false)
-
-    Cinematics.ExitNISMode()
 
     NorthVisMarker:Destroy()
     IntroMission1()
@@ -912,65 +959,67 @@ end
 function IntroMission2NIS()
     ScenarioFramework.SetPlayableArea('M2_Playable_Area', false)
 
-    -- Get those engineers building the bombers, guaranteed
-    ArmyBrains[Seraphim]:PBMSetCheckInterval(2)
+    if not SkipNIS2 then
+        -- Get those engineers building the bombers, guaranteed
+        ArmyBrains[Seraphim]:PBMSetCheckInterval(2)
 
-    local AllShieldUnits = ArmyBrains[Seraphim]:GetListOfUnits(categories.SHIELD, false)
+        local AllShieldUnits = ArmyBrains[Seraphim]:GetListOfUnits(categories.SHIELD, false)
 
-    ForkThread(ShieldToggle, AllShieldUnits, false, false)
+        ForkThread(ShieldToggle, AllShieldUnits, false, false)
 
-    local VisMarker = ScenarioFramework.CreateVisibleAreaLocation(75, ScenarioUtils.MarkerToPosition('M2_Seraph_Exper_Base'), 0, ArmyBrains[Player])
-    ScenarioFramework.CreateVisibleAreaLocation(50, ScenarioUtils.MarkerToPosition('M2_Resource_Base'), 0.1, ArmyBrains[Player])
+        local VisMarker = ScenarioFramework.CreateVisibleAreaLocation(75, ScenarioUtils.MarkerToPosition('M2_Seraph_Exper_Base'), 0, ArmyBrains[Player])
+        ScenarioFramework.CreateVisibleAreaLocation(50, ScenarioUtils.MarkerToPosition('M2_Resource_Base'), 0.1, ArmyBrains[Player])
 
-    Cinematics.EnterNISMode()
-    Cinematics.SetInvincible('M1_Playable_Area')
+        Cinematics.EnterNISMode()
+        Cinematics.SetInvincible('M1_Playable_Area')
 
-    WaitSeconds(3.5)
+        WaitSeconds(3.5)
 
-    ScenarioFramework.Dialogue(OpStrings.X03_M02_016, nil, true)
-    ScenarioFramework.Dialogue(OpStrings.X03_M02_017, nil, true)
+        ScenarioFramework.Dialogue(OpStrings.X03_M02_016, nil, true)
+        ScenarioFramework.Dialogue(OpStrings.X03_M02_017, nil, true)
 
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_1'), 0)
-    WaitSeconds(1)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_2'), 7)
-    WaitSeconds(1)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_1'), 0)
+        WaitSeconds(1)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_2'), 7)
+        WaitSeconds(1)
 
-    -- Set it back to the default
-    ArmyBrains[Seraphim]:PBMSetCheckInterval(13)
+        -- Set it back to the default
+        ArmyBrains[Seraphim]:PBMSetCheckInterval(13)
 
-    -- Look north
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_3'), 4)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_4'), 3)
-    WaitSeconds(1)
-    ScenarioFramework.Dialogue(OpStrings.X03_M02_018, nil, true)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_5'), 5)
-    WaitSeconds(2)
-    -- Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_6'), 3)
-    Cinematics.CameraTrackEntity(ScenarioInfo.PlayerCDR, 40, 4)
-    VisMarker:Destroy()
+        -- Look north
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_3'), 4)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_4'), 3)
+        WaitSeconds(1)
+        ScenarioFramework.Dialogue(OpStrings.X03_M02_018, nil, true)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_5'), 5)
+        WaitSeconds(2)
+        -- Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_6'), 3)
+        Cinematics.CameraTrackEntity(ScenarioInfo.PlayerCDR, 40, 4)
+        VisMarker:Destroy()
 
-    local fakeMarker1 = {
-        ['zoom'] = FLOAT(140),
-        ['canSetCamera'] = BOOLEAN(true),
-        ['canSyncCamera'] = BOOLEAN(true),
-        ['color'] = STRING('ff808000'),
-        ['editorIcon'] = STRING('/textures/editor/marker_mass.bmp'),
-        ['type'] = STRING('Camera Info'),
-        ['prop'] = STRING('/env/common/props/markers/M_Camera_prop.bp'),
-        ['orientation'] = VECTOR3(-3.14159, 1.19772, 0),
-        ['position'] = ScenarioInfo.PlayerCDR:GetPosition(),
-    }
-    Cinematics.CameraMoveToMarker(fakeMarker1, 1.5)
+        local fakeMarker1 = {
+            ['zoom'] = FLOAT(140),
+            ['canSetCamera'] = BOOLEAN(true),
+            ['canSyncCamera'] = BOOLEAN(true),
+            ['color'] = STRING('ff808000'),
+            ['editorIcon'] = STRING('/textures/editor/marker_mass.bmp'),
+            ['type'] = STRING('Camera Info'),
+            ['prop'] = STRING('/env/common/props/markers/M_Camera_prop.bp'),
+            ['orientation'] = VECTOR3(-3.14159, 1.19772, 0),
+            ['position'] = ScenarioInfo.PlayerCDR:GetPosition(),
+        }
+        Cinematics.CameraMoveToMarker(fakeMarker1, 1.5)
 
-    -- WaitSeconds(1)
+        -- WaitSeconds(1)
 
-    ScenarioFramework.ClearIntel(ScenarioUtils.MarkerToPosition('M2_Seraph_Exper_Base'), 80)
-    ScenarioFramework.ClearIntel(ScenarioUtils.MarkerToPosition('M2_Resource_Base'), 80)
-    Cinematics.SetInvincible('M1_Playable_Area', true)
-    Cinematics.ExitNISMode()
+        ScenarioFramework.ClearIntel(ScenarioUtils.MarkerToPosition('M2_Seraph_Exper_Base'), 80)
+        ScenarioFramework.ClearIntel(ScenarioUtils.MarkerToPosition('M2_Resource_Base'), 80)
+        Cinematics.SetInvincible('M1_Playable_Area', true)
+        Cinematics.ExitNISMode()
 
-    ForkThread(ShieldToggle, AllShieldUnits, true, true)
-
+        ForkThread(ShieldToggle, AllShieldUnits, true, true)
+    end
+    
     StartMission2()
 
     WaitSeconds(1)

--- a/X1CA_Coop_004/X1CA_Coop_004_script.lua
+++ b/X1CA_Coop_004/X1CA_Coop_004_script.lua
@@ -51,6 +51,13 @@ local NukeHandles = {}
 -- How long should we wait at the beginning of the NIS to allow slower machines to catch up?
 local NIS1InitialDelay = 3
 
+-------------
+-- Debug only!
+-------------
+local SkipNIS1 = false
+local SkipNIS2 = false
+local SkipNIS3 = false
+
 ----------------
 -- Taunt Managers
 ----------------
@@ -127,7 +134,9 @@ function OnStart(self)
         )
     end
 
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1'), 0)
+    if not SkipNIS1 then
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1'), 0)
+    end
 
     ForkThread(IntroMission1NIS)
 end
@@ -156,69 +165,79 @@ end
 -- Intro NIS
 -----------
 function IntroMission1NIS()
-    Cinematics.EnterNISMode()
+    if not SkipNIS1 then
+        Cinematics.EnterNISMode()
 
-    -- Let slower machines catch up before we get going
-    WaitSeconds(NIS1InitialDelay)
+        -- Let slower machines catch up before we get going
+        WaitSeconds(NIS1InitialDelay)
 
-    ScenarioFramework.Dialogue(OpStrings.X04_M01_010, nil, true)
+        ScenarioFramework.Dialogue(OpStrings.X04_M01_010, nil, true)
 
-    ScenarioFramework.CreateVisibleAreaLocation(30, ScenarioUtils.MarkerToPosition('NIS_M1_Reveal_1'), 15, ArmyBrains[Player])
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1'), 0)
-    WaitSeconds(2)
-
-    -- Dostya begins constructing a building
-    -- If we need her to build another, add
-    -- 'Dostya_build_target_2'
-    -- to the function
-
-    -- Spawn Dostya for NIS
-    -- ScenarioInfo.DostyaCDR = ScenarioUtils.CreateArmyUnit('Dostya', 'Dostya')
-    ScenarioInfo.DostyaCDR = ScenarioFramework.EngineerBuildUnits('Dostya', 'Dostya', 'Dostya_build_target_1')
-    ScenarioInfo.DostyaCDR:PlayCommanderWarpInEffect()
-    ScenarioInfo.DostyaCDR:SetCustomName(LOC '{i Dostya}')
-    ScenarioInfo.DostyaCDR:SetCanBeKilled(false)
-    ScenarioFramework.CreateUnitDeathTrigger(DostyaDeath, ScenarioInfo.DostyaCDR)
-
-    -- "I am detecting an enemy base two clicks north of my position. I will advance and attack in 10 minutes. Dostya out."
-    ScenarioFramework.Dialogue(OpStrings.X04_M01_020, nil, true)
-    -- "Roger. HQ out"
-    ScenarioFramework.Dialogue(OpStrings.X04_M01_028, nil, true)
-
-    WaitSeconds(1)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_2'), 10)
-    WaitSeconds(1)
-
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_3_2'), 3)
-
-    -- Spawn in player
-    ForkThread(SpawnPlayer)
-
-    -- Play dialog: HQ: You're going to have concerns of your own, Commander.
-    ScenarioFramework.Dialogue(OpStrings.X04_M01_023, nil, true)
-    WaitSeconds(1)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_3'), 4)
-    -- WaitSeconds(1)
-
-    -- ScenarioFramework.CreateVisibleAreaLocation(15, ScenarioUtils.MarkerToPosition('NIS_M1_Reveal_2'), 14, ArmyBrains[Player])
-    local tempVisMarker = ScenarioFramework.CreateVisibleAreaLocation(50, ScenarioUtils.MarkerToPosition('NIS_M1_Reveal_3'), 0, ArmyBrains[Player])
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_4'), 5)
-    -- The enemy is west
-    ScenarioFramework.Dialogue(OpStrings.X04_M01_024, nil, true)
-    -- Kill 'em
-    ScenarioFramework.Dialogue(OpStrings.X04_M01_026, nil, true)
-
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_5'), 8)
-    WaitSeconds(1)
-    ForkThread(function()
+        ScenarioFramework.CreateVisibleAreaLocation(30, ScenarioUtils.MarkerToPosition('NIS_M1_Reveal_1'), 15, ArmyBrains[Player])
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1'), 0)
         WaitSeconds(2)
-        tempVisMarker:Destroy()
-        WaitSeconds(4)
-        ScenarioFramework.ClearIntel(ScenarioUtils.MarkerToPosition('NIS_M1_Reveal_3'), 50)
-    end)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_6'), 4)
-    WaitSeconds(1)
-    Cinematics.ExitNISMode()
+
+        -- Dostya begins constructing a building
+        -- If we need her to build another, add
+        -- 'Dostya_build_target_2'
+        -- to the function
+
+        -- Spawn Dostya for NIS
+        -- ScenarioInfo.DostyaCDR = ScenarioUtils.CreateArmyUnit('Dostya', 'Dostya')
+        ScenarioInfo.DostyaCDR = ScenarioFramework.EngineerBuildUnits('Dostya', 'Dostya', 'Dostya_build_target_1')
+        ScenarioInfo.DostyaCDR:PlayCommanderWarpInEffect()
+        ScenarioInfo.DostyaCDR:SetCustomName(LOC '{i Dostya}')
+        ScenarioInfo.DostyaCDR:SetCanBeKilled(false)
+        ScenarioFramework.CreateUnitDeathTrigger(DostyaDeath, ScenarioInfo.DostyaCDR)
+
+        -- "I am detecting an enemy base two clicks north of my position. I will advance and attack in 10 minutes. Dostya out."
+        ScenarioFramework.Dialogue(OpStrings.X04_M01_020, nil, true)
+        -- "Roger. HQ out"
+        ScenarioFramework.Dialogue(OpStrings.X04_M01_028, nil, true)
+
+        WaitSeconds(1)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_2'), 10)
+        WaitSeconds(1)
+
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_3_2'), 3)
+
+        -- Spawn in player
+        ForkThread(SpawnPlayer)
+
+        -- Play dialog: HQ: You're going to have concerns of your own, Commander.
+        ScenarioFramework.Dialogue(OpStrings.X04_M01_023, nil, true)
+        WaitSeconds(1)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_3'), 4)
+        -- WaitSeconds(1)
+
+        -- ScenarioFramework.CreateVisibleAreaLocation(15, ScenarioUtils.MarkerToPosition('NIS_M1_Reveal_2'), 14, ArmyBrains[Player])
+        local tempVisMarker = ScenarioFramework.CreateVisibleAreaLocation(50, ScenarioUtils.MarkerToPosition('NIS_M1_Reveal_3'), 0, ArmyBrains[Player])
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_4'), 5)
+        -- The enemy is west
+        ScenarioFramework.Dialogue(OpStrings.X04_M01_024, nil, true)
+        -- Kill 'em
+        ScenarioFramework.Dialogue(OpStrings.X04_M01_026, nil, true)
+
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_5'), 8)
+        WaitSeconds(1)
+        ForkThread(function()
+            WaitSeconds(2)
+            tempVisMarker:Destroy()
+            WaitSeconds(4)
+            ScenarioFramework.ClearIntel(ScenarioUtils.MarkerToPosition('NIS_M1_Reveal_3'), 50)
+        end)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_6'), 4)
+        WaitSeconds(1)
+        Cinematics.ExitNISMode()
+    else
+        ForkThread( SpawnPlayer )
+        ScenarioInfo.DostyaCDR = ScenarioUtils.CreateArmyUnit('Dostya', 'Dostya')
+        ScenarioInfo.DostyaCDR:PlayCommanderWarpInEffect()
+        ScenarioInfo.DostyaCDR:SetCustomName(LOC '{i Dostya}')
+        #ScenarioInfo.DostyaCDR:SetCanTakeDamage(false)
+        ScenarioInfo.DostyaCDR:SetCanBeKilled(false)
+        ScenarioFramework.CreateUnitDeathTrigger(DostyaDeath, ScenarioInfo.DostyaCDR)
+    end
 
     IntroMission1()
 end
@@ -482,32 +501,34 @@ function IntroMission2NIS()
     -- Show the jammer
     local visMarker = ScenarioFramework.CreateVisibleAreaLocation(3, ScenarioInfo.Jammer:GetPosition(), 2, ArmyBrains[Player])
 
-    Cinematics.EnterNISMode()
-    ScenarioFramework.Dialogue(OpStrings.X04_M02_002, nil, true)
-    WaitSeconds(2)
-    ScenarioFramework.Dialogue(OpStrings.X04_M02_003, nil, true)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_1'), 0)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_2'), 6)
-    WaitSeconds(1)
-    ScenarioFramework.Dialogue(OpStrings.X04_M02_004, nil, true)
+    if not SkipNIS2 then
+        Cinematics.EnterNISMode()
+        ScenarioFramework.Dialogue(OpStrings.X04_M02_002, nil, true)
+        WaitSeconds(2)
+        ScenarioFramework.Dialogue(OpStrings.X04_M02_003, nil, true)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_1'), 0)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_2'), 6)
+        WaitSeconds(1)
+        ScenarioFramework.Dialogue(OpStrings.X04_M02_004, nil, true)
 
-    local fakeMarker = {
-        ['zoom'] = FLOAT(65.1),
-        ['canSetCamera'] = BOOLEAN(true),
-        ['canSyncCamera'] = BOOLEAN(true),
-        ['color'] = STRING('ff808000'),
-        ['editorIcon'] = STRING('/textures/editor/marker_mass.bmp'),
-        ['type'] = STRING('Camera Info'),
-        ['prop'] = STRING('/env/common/props/markers/M_Camera_prop.bp'),
-        ['orientation'] = VECTOR3(-3.08869, 0.92, 0),
-        ['position'] = ScenarioInfo.PlayerCDR:GetPosition(),
-    }
+        local fakeMarker = {
+            ['zoom'] = FLOAT(65.1),
+            ['canSetCamera'] = BOOLEAN(true),
+            ['canSyncCamera'] = BOOLEAN(true),
+            ['color'] = STRING('ff808000'),
+            ['editorIcon'] = STRING('/textures/editor/marker_mass.bmp'),
+            ['type'] = STRING('Camera Info'),
+            ['prop'] = STRING('/env/common/props/markers/M_Camera_prop.bp'),
+            ['orientation'] = VECTOR3(-3.08869, 0.92, 0),
+            ['position'] = ScenarioInfo.PlayerCDR:GetPosition(),
+        }
 
-    -- Snap back to the commander's position, wherever he is
-    Cinematics.CameraMoveToMarker(fakeMarker, 0)
-    WaitSeconds(2)
+        -- Snap back to the commander's position, wherever he is
+        Cinematics.CameraMoveToMarker(fakeMarker, 0)
+        WaitSeconds(2)
 
-    Cinematics.ExitNISMode()
+        Cinematics.ExitNISMode()
+    end
 
     -- visMarker:Destroy()
 
@@ -825,26 +846,30 @@ function PreAttackDostya()
 end
 
 function AttackDostya()
-    local units = nil
+    if not SkipNIS3 then
+        local units = nil
 
-    IssueMove({ ScenarioInfo.DostyaCDR }, ScenarioUtils.MarkerToPosition('Dostya_Destination'))
+        IssueMove({ ScenarioInfo.DostyaCDR }, ScenarioUtils.MarkerToPosition('Dostya_Destination'))
 
-    units = ScenarioUtils.CreateArmyGroupAsPlatoon('Seraphim', 'M2DostyaAttackAir', 'GrowthFormation')
-    ScenarioFramework.PlatoonPatrolChain(units, 'DostyaAttackChain')
+        units = ScenarioUtils.CreateArmyGroupAsPlatoon('Seraphim', 'M2DostyaAttackAir', 'GrowthFormation')
+        ScenarioFramework.PlatoonPatrolChain(units, 'DostyaAttackChain')
 
-    units = ScenarioUtils.CreateArmyGroup('Seraphim', 'M2DostyaAttackLandEast')
-    ScenarioFramework.GroupPatrolChain(units, 'DostyaAttackChain')
+        units = ScenarioUtils.CreateArmyGroup('Seraphim', 'M2DostyaAttackLandEast')
+        ScenarioFramework.GroupPatrolChain(units, 'DostyaAttackChain')
 
-    units = ScenarioUtils.CreateArmyGroup('Seraphim', 'M2DostyaAttackLandWest')
-    ScenarioFramework.GroupPatrolChain(units, 'DostyaAttackChain')
+        units = ScenarioUtils.CreateArmyGroup('Seraphim', 'M2DostyaAttackLandWest')
+        ScenarioFramework.GroupPatrolChain(units, 'DostyaAttackChain')
 
-    -- Hex5
-    ScenarioInfo.Hex5 = ScenarioUtils.CreateArmyUnit('Seraphim', 'M2_Hex5')
-    ScenarioInfo.Hex5:SetCustomName(LOC '{i Hex5}')
-    ScenarioInfo.Hex5:SetCanTakeDamage(false)
-    ScenarioFramework.CreateTimerTrigger(Hex5Vanish, 60)
+        -- Hex5
+        ScenarioInfo.Hex5 = ScenarioUtils.CreateArmyUnit('Seraphim', 'M2_Hex5')
+        ScenarioInfo.Hex5:SetCustomName(LOC '{i Hex5}')
+        ScenarioInfo.Hex5:SetCanTakeDamage(false)
+        ScenarioFramework.CreateTimerTrigger(Hex5Vanish, 60)
 
-    ForkThread(IntroMission3NIS)
+        ForkThread(IntroMission3NIS)
+    else
+        ForkThread(IntroMission3)
+    end
 end
 
 function IntroMission3NIS()

--- a/X1CA_Coop_005/X1CA_Coop_005_script.lua
+++ b/X1CA_Coop_005/X1CA_Coop_005_script.lua
@@ -59,6 +59,13 @@ local Difficulty = ScenarioInfo.Options.Difficulty
 -- How long should we wait at the beginning of the NIS to allow slower machines to catch up?
 local NIS1InitialDelay = 3
 
+-------------
+-- Debug only!
+-------------
+local SkipNIS1 = false
+local SkipNIS2 = false
+local SkipNIS3 = false
+
 ----------------
 -- Taunt Managers
 ----------------
@@ -214,82 +221,125 @@ end
 function IntroMission1NIS()
     ScenarioFramework.SetPlayableArea('M1Area', false)
 
-    Cinematics.EnterNISMode()
+    if not SkipNIS1 then
+        Cinematics.EnterNISMode()
 
-    local VisMarker1 = ScenarioFramework.CreateVisibleAreaLocation(50, ScenarioUtils.MarkerToPosition('M1_Vis_1'), 0, ArmyBrains[Player])
-    local VisMarker2 = ScenarioFramework.CreateVisibleAreaLocation(20, ScenarioUtils.MarkerToPosition('M1_Vis_2'), 0, ArmyBrains[Player])
-    local VisMarker3 = ScenarioFramework.CreateVisibleAreaLocation(20, ScenarioUtils.MarkerToPosition('M1_Vis_3'), 0, ArmyBrains[Player])
+        local VisMarker1 = ScenarioFramework.CreateVisibleAreaLocation(50, ScenarioUtils.MarkerToPosition('M1_Vis_1'), 0, ArmyBrains[Player])
+        local VisMarker2 = ScenarioFramework.CreateVisibleAreaLocation(20, ScenarioUtils.MarkerToPosition('M1_Vis_2'), 0, ArmyBrains[Player])
+        local VisMarker3 = ScenarioFramework.CreateVisibleAreaLocation(20, ScenarioUtils.MarkerToPosition('M1_Vis_3'), 0, ArmyBrains[Player])
 
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1'), 0)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1'), 0)
 
-    -- Let slower machines catch up before we get going
-    WaitSeconds(NIS1InitialDelay)
+        -- Let slower machines catch up before we get going
+        WaitSeconds(NIS1InitialDelay)
 
-    WaitSeconds(1)
-    ScenarioFramework.Dialogue(OpStrings.X05_M01_010, nil, true)
-    WaitSeconds(3)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_2'), 5)
-    WaitSeconds(3)
+        WaitSeconds(1)
+        ScenarioFramework.Dialogue(OpStrings.X05_M01_010, nil, true)
+        WaitSeconds(3)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_2'), 5)
+        WaitSeconds(3)
 
-    ScenarioFramework.Dialogue(OpStrings.X05_M01_011, nil, true)
+        ScenarioFramework.Dialogue(OpStrings.X05_M01_011, nil, true)
 
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_3'), 3)
-    WaitSeconds(2)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_4'), 3)
-    WaitSeconds(2)
-    ForkThread(function()
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_3'), 3)
         WaitSeconds(2)
-        VisMarker1:Destroy()
-        VisMarker2:Destroy()
-        VisMarker3:Destroy()
-        WaitSeconds(4)
-        ScenarioFramework.ClearIntel(ScenarioUtils.MarkerToPosition('M1_Vis_1'), 60)
-        ScenarioFramework.ClearIntel(ScenarioUtils.MarkerToPosition('M1_Vis_2'), 30)
-        ScenarioFramework.ClearIntel(ScenarioUtils.MarkerToPosition('M1_Vis_3'), 30)
-    end)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_5'), 4)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_4'), 3)
+        WaitSeconds(2)
+        ForkThread(function()
+            WaitSeconds(2)
+            VisMarker1:Destroy()
+            VisMarker2:Destroy()
+            VisMarker3:Destroy()
+            WaitSeconds(4)
+            ScenarioFramework.ClearIntel(ScenarioUtils.MarkerToPosition('M1_Vis_1'), 60)
+            ScenarioFramework.ClearIntel(ScenarioUtils.MarkerToPosition('M1_Vis_2'), 30)
+            ScenarioFramework.ClearIntel(ScenarioUtils.MarkerToPosition('M1_Vis_3'), 30)
+        end)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_5'), 4)
 
-    if (LeaderFaction == 'aeon') then
-        ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'AeonPlayer')
-    elseif (LeaderFaction == 'cybran') then
-        ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'CybranPlayer')
-    elseif (LeaderFaction == 'uef') then
-        ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'UEFPlayer')
-    end
-
-    ScenarioInfo.PlayerCDR:PlayCommanderWarpInEffect()
-    ScenarioFramework.PauseUnitDeath(ScenarioInfo.PlayerCDR)
-    ScenarioFramework.CreateUnitDeathTrigger(PlayerDeath, ScenarioInfo.PlayerCDR)
-
-    -- spawn coop players too
-    ScenarioInfo.CoopCDR = {}
-    local tblArmy = ListArmies()
-    coop = 1
-    for iArmy, strArmy in pairs(tblArmy) do
-        if iArmy >= ScenarioInfo.Coop1 then
-            factionIdx = GetArmyBrain(strArmy):GetFactionIndex()
-            if (factionIdx == 1) then
-                ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'UEFPlayer')
-            elseif (factionIdx == 2) then
-                ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'AeonPlayer')
-            else
-                ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'CybranPlayer')
-            end
-            ScenarioInfo.CoopCDR[coop]:PlayCommanderWarpInEffect()
-            coop = coop + 1
-            WaitSeconds(0.5)
+        if (LeaderFaction == 'aeon') then
+            ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'AeonPlayer')
+        elseif (LeaderFaction == 'cybran') then
+            ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'CybranPlayer')
+        elseif (LeaderFaction == 'uef') then
+            ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'UEFPlayer')
         end
+
+        ScenarioInfo.PlayerCDR:PlayCommanderWarpInEffect()
+        ScenarioFramework.PauseUnitDeath(ScenarioInfo.PlayerCDR)
+        ScenarioFramework.CreateUnitDeathTrigger(PlayerDeath, ScenarioInfo.PlayerCDR)
+
+        -- spawn coop players too
+        ScenarioInfo.CoopCDR = {}
+        local tblArmy = ListArmies()
+        coop = 1
+        for iArmy, strArmy in pairs(tblArmy) do
+            if iArmy >= ScenarioInfo.Coop1 then
+                factionIdx = GetArmyBrain(strArmy):GetFactionIndex()
+                if (factionIdx == 1) then
+                    ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'UEFPlayer')
+                elseif (factionIdx == 2) then
+                    ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'AeonPlayer')
+                else
+                    ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'CybranPlayer')
+                end
+                ScenarioInfo.CoopCDR[coop]:PlayCommanderWarpInEffect()
+                coop = coop + 1
+                WaitSeconds(0.5)
+            end
+        end
+
+        for index, coopACU in ScenarioInfo.CoopCDR do
+            ScenarioFramework.PauseUnitDeath(coopACU)
+            ScenarioFramework.CreateUnitDeathTrigger(PlayerDeath, coopACU)
+        end
+
+        ScenarioFramework.Dialogue(OpStrings.X05_M01_012, nil, true)
+        WaitSeconds(2)
+
+        Cinematics.ExitNISMode()
+    else
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_5'), 4)
+
+        if (LeaderFaction == 'aeon') then
+            ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'AeonPlayer')
+        elseif (LeaderFaction == 'cybran') then
+            ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'CybranPlayer')
+        elseif (LeaderFaction == 'uef') then
+            ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'UEFPlayer')
+        end
+
+        ScenarioInfo.PlayerCDR:PlayCommanderWarpInEffect()
+        ScenarioFramework.PauseUnitDeath(ScenarioInfo.PlayerCDR)
+        ScenarioFramework.CreateUnitDeathTrigger(PlayerDeath, ScenarioInfo.PlayerCDR)
+
+        -- spawn coop players too
+        ScenarioInfo.CoopCDR = {}
+        local tblArmy = ListArmies()
+        coop = 1
+        for iArmy, strArmy in pairs(tblArmy) do
+            if iArmy >= ScenarioInfo.Coop1 then
+                factionIdx = GetArmyBrain(strArmy):GetFactionIndex()
+                if (factionIdx == 1) then
+                    ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'UEFPlayer')
+                elseif (factionIdx == 2) then
+                    ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'AeonPlayer')
+                else
+                    ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'CybranPlayer')
+                end
+                ScenarioInfo.CoopCDR[coop]:PlayCommanderWarpInEffect()
+                coop = coop + 1
+                WaitSeconds(0.5)
+            end
+        end
+
+        for index, coopACU in ScenarioInfo.CoopCDR do
+            ScenarioFramework.PauseUnitDeath(coopACU)
+            ScenarioFramework.CreateUnitDeathTrigger(PlayerDeath, coopACU)
+        end
+
+        WaitSeconds(0.1)
     end
-
-    for index, coopACU in ScenarioInfo.CoopCDR do
-        ScenarioFramework.PauseUnitDeath(coopACU)
-        ScenarioFramework.CreateUnitDeathTrigger(PlayerDeath, coopACU)
-    end
-
-    ScenarioFramework.Dialogue(OpStrings.X05_M01_012, nil, true)
-    WaitSeconds(2)
-
-    Cinematics.ExitNISMode()
 
     IntroMission1()
 end
@@ -686,34 +736,36 @@ end
 
 function IntroMission2NIS()
     ScenarioFramework.SetPlayableArea('M2Area', false)
-    Cinematics.EnterNISMode()
-    Cinematics.SetInvincible('M1Area')
+    if (not SkipNIS2) then
+        Cinematics.EnterNISMode()
+        Cinematics.SetInvincible('M1Area')
 
-    -- Ensure that Fletcher starts building his base sooner rather than later
-    ArmyBrains[Fletcher]:PBMSetCheckInterval(2)
+        -- Ensure that Fletcher starts building his base sooner rather than later
+        ArmyBrains[Fletcher]:PBMSetCheckInterval(2)
 
-    WaitSeconds(1)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_1'), 0)
-    WaitSeconds(1)
+        WaitSeconds(1)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_1'), 0)
+        WaitSeconds(1)
 
-    -- Play faction appropriate dialogue from Fletcher
-    if (LeaderFaction == 'uef') then
-        ScenarioFramework.Dialogue(OpStrings.X05_M01_040, nil, true)
-    elseif (LeaderFaction == 'cybran') then
-        ScenarioFramework.Dialogue(OpStrings.X05_M01_050, nil, true)
-    elseif (LeaderFaction == 'aeon') then
-        ScenarioFramework.Dialogue(OpStrings.X05_M01_060, nil, true)
+        -- Play faction appropriate dialogue from Fletcher
+        if (LeaderFaction == 'uef') then
+            ScenarioFramework.Dialogue(OpStrings.X05_M01_040, nil, true)
+        elseif (LeaderFaction == 'cybran') then
+            ScenarioFramework.Dialogue(OpStrings.X05_M01_050, nil, true)
+        elseif (LeaderFaction == 'aeon') then
+            ScenarioFramework.Dialogue(OpStrings.X05_M01_060, nil, true)
+        end
+
+        WaitSeconds(1)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_2'), 3)
+
+        Cinematics.SetInvincible('M1Area', true)
+        Cinematics.ExitNISMode()
+        -- Post-NIS comment from Brackman
+        ScenarioFramework.Dialogue(OpStrings.X05_M01_190)
+        -- Set back to default
+        ArmyBrains[Fletcher]:PBMSetCheckInterval(6)
     end
-
-    WaitSeconds(1)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_2_2'), 3)
-
-    Cinematics.SetInvincible('M1Area', true)
-    Cinematics.ExitNISMode()
-    -- Post-NIS comment from Brackman
-    ScenarioFramework.Dialogue(OpStrings.X05_M01_190)
-    -- Set back to default
-    ArmyBrains[Fletcher]:PBMSetCheckInterval(6)
 
     M2Counterattack()
     StartMission2()
@@ -1023,8 +1075,12 @@ function StartMission2()
                 while(ScenarioInfo.DialogueLock) do
                     WaitSeconds(0.2)
                 end
-                ScenarioFramework.CDRDeathNISCamera(ScenarioInfo.Hex5CDR, 5)
-                ScenarioFramework.Dialogue(OpStrings.X05_M02_200, IntroMission3, true)
+                if (not SkipNIS2) then
+                    ScenarioFramework.CDRDeathNISCamera(ScenarioInfo.Hex5CDR, 5)
+                    ScenarioFramework.Dialogue(OpStrings.X05_M02_200, IntroMission3, true)
+                else
+                    IntroMission3()
+                end
                 -- torch Hex5s remaining units
                 -- local units = ArmyBrains[Hex5]:GetListOfUnits(categories.ALLUNITS, false)
                 -- for k,v in units do
@@ -1404,30 +1460,32 @@ function IntroMission3NIS()
     -- Visibility on QAI
     ScenarioFramework.CreateVisibleAreaLocation(40, ScenarioUtils.MarkerToPosition('M3_Vis_1'), 2, ArmyBrains[Player])
 
-    Cinematics.EnterNISMode()
-    Cinematics.SetInvincible('M2Area')
+    if (not SkipNIS3) then
+        Cinematics.EnterNISMode()
+        Cinematics.SetInvincible('M2Area')
 
-    WaitSeconds(1)
+        WaitSeconds(1)
 
-    ScenarioFramework.Dialogue(OpStrings.X05_M02_201, nil, true)
+        ScenarioFramework.Dialogue(OpStrings.X05_M02_201, nil, true)
 
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_3_1_2'), 0)
-    WaitSeconds(1)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_3_1'), 4)
-    WaitSeconds(1)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_3_1_2'), 0)
+        WaitSeconds(1)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_3_1'), 4)
+        WaitSeconds(1)
 
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_3_2'), 3)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_3_3'), 4)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_3_2'), 3)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_3_3'), 4)
 
-    ScenarioFramework.Dialogue(OpStrings.X05_M02_202, nil, true)
-    ScenarioFramework.Dialogue(OpStrings.X05_M02_203, nil, true)
+        ScenarioFramework.Dialogue(OpStrings.X05_M02_202, nil, true)
+        ScenarioFramework.Dialogue(OpStrings.X05_M02_203, nil, true)
 
-    -- WaitSeconds(1)
-    Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_3_4'), 3)
-    WaitSeconds(3)
+        -- WaitSeconds(1)
+        Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_3_4'), 3)
+        WaitSeconds(3)
 
-    Cinematics.SetInvincible('M2Area', true)
-    Cinematics.ExitNISMode()
+        Cinematics.SetInvincible('M2Area', true)
+        Cinematics.ExitNISMode()
+    end
 
     M3Counterattack()
     StartMission3()

--- a/X1CA_Coop_006/X1CA_Coop_006_script.lua
+++ b/X1CA_Coop_006/X1CA_Coop_006_script.lua
@@ -73,6 +73,12 @@ local FletcherTurned = false -- to keep track during the second NIS
 -- How long should we wait at the beginning of the NIS to allow slower machines to catch up?
 local NIS1InitialDelay = 3
 
+-------------
+-- Debug only!
+-------------
+local SkipNIS1 = false
+local SkipPreMission2Dialog = false
+
 ----------------
 -- Taunt Managers
 ----------------
@@ -332,55 +338,102 @@ function IntroMission1NIS()
             SubCommanderFletcher:SetCustomName(LOC '{i sCDR_Romaska}')
             SubCommanderRhiza:SetCustomName(LOC '{i sCDR_St_Croix}')
 
-            Cinematics.EnterNISMode()
+            if not SkipNIS1 then
+                Cinematics.EnterNISMode()
 
-            Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1'), 0)
+                Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_1'), 0)
 
-            -- Let slower machines catch up before we get going
-            WaitSeconds(NIS1InitialDelay)
+                -- Let slower machines catch up before we get going
+                WaitSeconds(NIS1InitialDelay)
 
-            -- Fletcher's reinforcements
-            if (LeaderFaction == 'uef') then
-                ScenarioFramework.Dialogue(OpStrings.X06_M01_020, nil, true)
-            elseif (LeaderFaction == 'cybran') then
-                ScenarioFramework.Dialogue(OpStrings.X06_M01_030, nil, true)
-            elseif (LeaderFaction == 'aeon') then
-                ScenarioFramework.Dialogue(OpStrings.X06_M01_040, nil, true)
-            end
+                -- Fletcher's reinforcements
+                if (LeaderFaction == 'uef') then
+                    ScenarioFramework.Dialogue(OpStrings.X06_M01_020, nil, true)
+                elseif (LeaderFaction == 'cybran') then
+                    ScenarioFramework.Dialogue(OpStrings.X06_M01_030, nil, true)
+                elseif (LeaderFaction == 'aeon') then
+                    ScenarioFramework.Dialogue(OpStrings.X06_M01_040, nil, true)
+                end
 
-            WaitSeconds(1)
-            Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_2'), 8)
-            ForkThread(sACUFletcherAI, SubCommanderFletcher)
-            WaitSeconds(2)
-
-            Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_3'), 3)
-
-            -- Rhiza's reinforcements
-            if (LeaderFaction == 'aeon') then
-                ScenarioFramework.Dialogue(OpStrings.X06_M01_055, nil, true)
-            else
-                ScenarioFramework.Dialogue(OpStrings.X06_M01_050, nil, true)
-            end
-
-            ScenarioFramework.CreateVisibleAreaLocation(100, ScenarioUtils.MarkerToPosition('M3_Seraph_LandAttack2_9'), 1, ArmyBrains[Player])
-            ScenarioFramework.CreateVisibleAreaLocation(30, ScenarioUtils.MarkerToPosition('M2_Order_AirAttack_1_3'), 1, ArmyBrains[Player])
-
-            WaitSeconds(1)
-            Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_4'), 3)
-            ForkThread(sACURhizaAI, SubCommanderRhiza)
-            WaitSeconds(1)
-
-            -- Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_5'), 3)
-            -- WaitSeconds(1)
-            -- The plan of attack
-            if (LeaderFaction == 'aeon') then
-                ScenarioFramework.Dialogue(OpStrings.X06_M01_065, nil, true)
-            else
-                ScenarioFramework.Dialogue(OpStrings.X06_M01_060, nil, true)
-            end
-
-            ForkThread(function()
                 WaitSeconds(1)
+                Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_2'), 8)
+                ForkThread(sACUFletcherAI, SubCommanderFletcher)
+                WaitSeconds(2)
+
+                Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_3'), 3)
+
+                -- Rhiza's reinforcements
+                if (LeaderFaction == 'aeon') then
+                    ScenarioFramework.Dialogue(OpStrings.X06_M01_055, nil, true)
+                else
+                    ScenarioFramework.Dialogue(OpStrings.X06_M01_050, nil, true)
+                end
+
+                ScenarioFramework.CreateVisibleAreaLocation(100, ScenarioUtils.MarkerToPosition('M3_Seraph_LandAttack2_9'), 1, ArmyBrains[Player])
+                ScenarioFramework.CreateVisibleAreaLocation(30, ScenarioUtils.MarkerToPosition('M2_Order_AirAttack_1_3'), 1, ArmyBrains[Player])
+
+                WaitSeconds(1)
+                Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_4'), 3)
+                ForkThread(sACURhizaAI, SubCommanderRhiza)
+                WaitSeconds(1)
+
+                -- Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_5'), 3)
+                -- WaitSeconds(1)
+                -- The plan of attack
+                if (LeaderFaction == 'aeon') then
+                    ScenarioFramework.Dialogue(OpStrings.X06_M01_065, nil, true)
+                else
+                    ScenarioFramework.Dialogue(OpStrings.X06_M01_060, nil, true)
+                end
+
+                ForkThread(function()
+                    WaitSeconds(1)
+                    if (LeaderFaction == 'aeon') then
+                        ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'AeonPlayer')
+                    elseif (LeaderFaction == 'cybran') then
+                        ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'CybranPlayer')
+                    elseif (LeaderFaction == 'uef') then
+                        ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'UEFPlayer')
+                    end
+                    ScenarioInfo.PlayerCDR:PlayCommanderWarpInEffect()
+                    ScenarioFramework.PauseUnitDeath(ScenarioInfo.PlayerCDR)
+                    ScenarioFramework.CreateUnitDeathTrigger(PlayerLose, ScenarioInfo.PlayerCDR)
+
+                    -- spawn coop players too
+                    ScenarioInfo.CoopCDR = {}
+                    local tblArmy = ListArmies()
+                    coop = 1
+                    for iArmy, strArmy in pairs(tblArmy) do
+                        if iArmy >= ScenarioInfo.Coop1 then
+                            factionIdx = GetArmyBrain(strArmy):GetFactionIndex()
+                            if (factionIdx == 1) then
+                                ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'UEFPlayer')
+                            elseif (factionIdx == 2) then
+                                ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'AeonPlayer')
+                            else
+                                ScenarioInfo.CoopCDR[coop] = ScenarioUtils.CreateArmyUnit(strArmy, 'CybranPlayer')
+                            end
+                            ScenarioInfo.CoopCDR[coop]:PlayCommanderWarpInEffect()
+                            coop = coop + 1
+                            WaitSeconds(0.5)
+                        end
+                    end
+
+                    for index, coopACU in ScenarioInfo.CoopCDR do
+                        ScenarioFramework.PauseUnitDeath(coopACU)
+                        ScenarioFramework.CreateUnitDeathTrigger(PlayerLose, coopACU)
+                    end
+                end)
+
+                Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_6'), 3)
+                WaitSeconds(1)
+
+                -- Closing statement
+                ScenarioFramework.Dialogue(OpStrings.X06_M01_010, nil, true)
+                Cinematics.ExitNISMode()
+            else
+                ForkThread(sACUFletcherAI, SubCommanderFletcher)
+                ForkThread(sACURhizaAI, SubCommanderRhiza)
                 if (LeaderFaction == 'aeon') then
                     ScenarioInfo.PlayerCDR = ScenarioUtils.CreateArmyUnit('Player', 'AeonPlayer')
                 elseif (LeaderFaction == 'cybran') then
@@ -416,14 +469,7 @@ function IntroMission1NIS()
                     ScenarioFramework.PauseUnitDeath(coopACU)
                     ScenarioFramework.CreateUnitDeathTrigger(PlayerLose, coopACU)
                 end
-            end)
-
-            Cinematics.CameraMoveToMarker(ScenarioUtils.GetMarker('Cam_1_6'), 3)
-            WaitSeconds(1)
-
-            -- Closing statement
-            ScenarioFramework.Dialogue(OpStrings.X06_M01_010, nil, true)
-            Cinematics.ExitNISMode()
+            end
 
             IntroMission1()
         end
@@ -785,7 +831,11 @@ function M2Seraphim()
 end
 
 function IntroMission2PreNIS()
-    ScenarioFramework.Dialogue(OpStrings.X06_M02_010, IntroMission2, true)
+    if not SkipPreMission2Dialog then
+        ScenarioFramework.Dialogue( OpStrings.X06_M02_010, IntroMission2, true )
+    else
+        ForkThread( IntroMission2 )
+    end
 end
 
 function IntroMission2NIS()


### PR DESCRIPTION
Extremely usefull for debugging missions. So you dont need to waste your
time watching same cinematics over and over again. This should have never been removed.