### PR TITLE
Stop Custom Plattons when Base Set Inactive

### DIFF
--- a/X1CA_Coop_003/X1CA_Coop_003_m1rhizaai.lua
+++ b/X1CA_Coop_003/X1CA_Coop_003_m1rhizaai.lua
@@ -96,6 +96,7 @@ function M1RhizaBaseLandAttacks()
         PlatoonType = 'Land',
         RequiresConstruction = true,
         BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M1_Rhiza_Base'}},
             { '/lua/editor/unitcountbuildconditions.lua', 'HaveLessThanUnitsWithCategory', {'default_brain', 10, categories.ual0309}},
         },
         LocationType = 'M1_Rhiza_Base',
@@ -117,6 +118,9 @@ function M1RhizaBaseLandAttacks()
         PlatoonType = 'Land',
         RequiresConstruction = true,
         LocationType = 'M1_Rhiza_Base',
+        BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M1_Rhiza_Base'}},
+        },
         PlatoonAIFunction = {'/maps/X1CA_Coop_003/X1CA_Coop_003_m1rhizaai.lua', 'M1RhizaAirAttackAI'},
     }
     ArmyBrains[Rhiza]:PBMAddPlatoon( builder )
@@ -186,6 +190,9 @@ function M1RhizaBaseAirAttacks()
         PlatoonType = 'Air',
         RequiresConstruction = true,
         LocationType = 'M1_Rhiza_Base',
+        BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M1_Rhiza_Base'}},
+        },
         PlatoonAIFunction = {'/maps/X1CA_Coop_003/X1CA_Coop_003_m1rhizaai.lua', 'M1RhizaAirAttackAI'},
     }
     ArmyBrains[Rhiza]:PBMAddPlatoon( builder )
@@ -371,6 +378,9 @@ function M1RhizaBaseNavalAttacks()
         PlatoonType = 'Sea',
         RequiresConstruction = true,
         LocationType = 'M1_Rhiza_Base',
+        BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M1_Rhiza_Base'}},
+        },
         PlatoonAIFunction = {'/maps/X1CA_Coop_003/X1CA_Coop_003_m1rhizaai.lua', 'RhizaNavalDEFENSEAI'},
     }
     ArmyBrains[Rhiza]:PBMAddPlatoon( builder )
@@ -388,6 +398,9 @@ function M1RhizaBaseNavalAttacks()
         PlatoonType = 'Sea',
         RequiresConstruction = true,
         LocationType = 'M1_Rhiza_Base',
+        BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M1_Rhiza_Base'}},
+        },
         PlatoonAIFunction = {SPAIFileName, 'RandomDefensePatrolThread'},
         PlatoonData = {
             PatrolChain = 'M1_Rhiza_SubDef_Chain',

--- a/X1CA_Coop_006/X1CA_Coop_006_m2rhizaai.lua
+++ b/X1CA_Coop_006/X1CA_Coop_006_m2rhizaai.lua
@@ -77,6 +77,9 @@ function CustomBuilders()
         PlatoonType = 'Land',
         RequiresConstruction = false,
         LocationType = 'M2_Rhiza_Base',
+        BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M2_Rhiza_Base'}},
+        },
         PlatoonAIFunction = {SPAIFileName, 'PatrolThread'},
         PlatoonData = {
             PatrolChain = 'M2_Rhiza_LandDef_Chain',
@@ -99,6 +102,7 @@ function CustomBuilders()
         PlatoonType = 'Land',
         RequiresConstruction = true,
         BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M2_Rhiza_Base'}},
             { '/lua/editor/unitcountbuildconditions.lua', 'HaveLessThanUnitsWithCategory', {'default_brain', 30, categories.ual0309}},
         },
         LocationType = 'M2_Rhiza_Base',
@@ -123,6 +127,7 @@ function CustomBuilders()
         PlatoonType = 'Air',
         RequiresConstruction = true,
         BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M2_Rhiza_Base'}},
             { '/lua/editor/unitcountbuildconditions.lua', 'HaveLessThanUnitsWithCategory', {'default_brain', 19, categories.ual0309}},
         },
         LocationType = 'M2_Rhiza_Base',
@@ -141,6 +146,7 @@ function CustomBuilders()
         PlatoonType = 'Air',
         RequiresConstruction = true,
         BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M2_Rhiza_Base'}},
             { '/lua/editor/unitcountbuildconditions.lua', 'HaveLessThanUnitsWithCategory', {'default_brain', 4, categories.uaa0104}},
         },
         LocationType = 'M2_Rhiza_Base',
@@ -164,6 +170,9 @@ function CustomBuilders()
         PlatoonType = 'Air',
         RequiresConstruction = true,
         LocationType = 'M2_Rhiza_Base',
+        BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M2_Rhiza_Base'}},
+        },
         PlatoonAIFunction = {ThisFile, 'RhizaNavalAI'},
     }
     ArmyBrains[Rhiza]:PBMAddPlatoon( Air1Builder )
@@ -186,6 +195,7 @@ function CustomBuilders()
         PlatoonType = 'Sea',
         RequiresConstruction = true,
         BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M2_Rhiza_Base'}},
             { '/lua/editor/unitcountbuildconditions.lua', 'HaveLessThanUnitsWithCategory', {'default_brain', 23, categories.ual0309}},
         },
         LocationType = 'M2_Rhiza_Base',
@@ -206,6 +216,9 @@ function CustomBuilders()
         PlatoonType = 'Sea',
         RequiresConstruction = true,
         LocationType = 'M2_Rhiza_Base',
+        BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M2_Rhiza_Base'}},
+        },
         PlatoonAIFunction = {ThisFile, 'RhizaNavalAI'},
     }
     ArmyBrains[Rhiza]:PBMAddPlatoon( Navy1Builder )
@@ -223,6 +236,9 @@ function CustomBuilders()
         PlatoonType = 'Sea',
         RequiresConstruction = true,
         LocationType = 'M2_Rhiza_Base',
+        BuildConditions = {
+            { '/lua/editor/BaseManagerBuildConditions.lua', 'BaseActive', {'M2_Rhiza_Base'}},
+        },
         PlatoonAIFunction = {SPAIFileName, 'PatrolThread'},
         PlatoonData = {
             PatrolChain = 'M2_Rhiza_NavalDef_Chain',


### PR DESCRIPTION
Added build condition that is in all OpAI attacks. No longer build units
when base is set as inactive. That is a case when friendly AI ACU
teleports out cause of taking too much damage. Custom platoons were
missing this build condition.