### PR TITLE
Dont try to play VOs for cybran that don't exist

### DIFF
--- a/X1CA_Coop_001/X1CA_Coop_001_script.lua
+++ b/X1CA_Coop_001/X1CA_Coop_001_script.lua
@@ -908,7 +908,9 @@ function StartMission1()
 end
 
 function M1SubPlot()
-    if ScenarioInfo.MissionNumber == 1 then
+    if (LeaderFaction == 'cybran' and ScenarioInfo.MissionNumber == 1) then
+        return
+    elseif ScenarioInfo.MissionNumber == 1 then
         ScenarioFramework.Dialogue(VoiceOvers.MoveInland)
     end
 end
@@ -2644,6 +2646,9 @@ function DeathNIS(unit)
 end
 
 function M4Subplot()
+    if LeaderFaction == 'cybran' then
+        return
+    end
     ScenarioFramework.Dialogue(VoiceOvers.M4Subplot)
 end
 


### PR DESCRIPTION
Some of the voice overs are just for UEF and Aeon and new system for
voice overs didn't count with that. So if Leader Faction was cybran and
script get the this point, it bugged out and map didn't expand after
finishing objectives.