### PR TITLE
Cybran M4 - Changed how the Aeon Commander death cutscene triggers

### DIFF
--- a/SCCA_Coop_R04/SCCA_Coop_R04_script.lua
+++ b/SCCA_Coop_R04/SCCA_Coop_R04_script.lua
@@ -1148,7 +1148,7 @@ function BeginMission3()
     ScenarioInfo.AeonCommanderM3:CreateEnhancement('AdvancedEngineering')
     ScenarioInfo.AeonCommanderM3:CreateEnhancement('Teleporter')
     ScenarioInfo.AeonCommanderM3:SetDoNotTarget(true) -- prevent auto-targetting until the EMP goes off
-    ScenarioFramework.CreateUnitDeathTrigger( EnemyCommanderDied, ScenarioInfo.AeonCommanderM3 )
+    --ScenarioFramework.CreateUnitDeathTrigger( EnemyCommanderDied, ScenarioInfo.AeonCommanderM3 )
     -- Don't delay the explosion for now, as killing the commander would trigger the main frame destruction
     -- ScenarioFramework.PauseUnitDeath( ScenarioInfo.AeonCommanderM3 ) -- 
 
@@ -1517,6 +1517,13 @@ function EMPTriggered()
             Units = { ScenarioInfo.AeonCommanderM3 },
         }
     )
+	ScenarioInfo.M3P3Objective:AddResultCallback(
+		function(result)
+			if result then
+				EnemyCommanderDied()
+			end
+		end
+	)
 	
 	-- Now it's legitimate to kill commander, delay the explosion so we can watch it on camera
 	ScenarioFramework.PauseUnitDeath( ScenarioInfo.AeonCommanderM3 )


### PR DESCRIPTION
The trigger for the function EnemyCommanderDied has been changed from a unit death trigger to an objective complete callback. This will prevent the ending cut scene from playing twice. 

This will resolve Issue #233