### PR TITLE
Dont play same dialogue for both UEF ACUs

### DIFF
--- a/SCCA_Coop_A01/SCCA_Coop_A01_script.lua
+++ b/SCCA_Coop_A01/SCCA_Coop_A01_script.lua
@@ -1457,7 +1457,6 @@ function M7_FauxUEFCommanderKilled()
         EndOperationCounter()
 
             if EndOperationCount < 3 then
-                ScenarioFramework.Dialogue(OpStrings.A01_M07_110)
 -- Kill Commander and continue op cam
                 ScenarioFramework.CDRDeathNISCamera(ScenarioInfo.M7_FauxUEFCommanderUnit, 7)
             else


### PR DESCRIPTION
Main UEF ACU has the same dialogue when dying as the junior ACU, it
looks like it always was this case.
Fixes #248