### PR TITLE
Update .gitattributes with text=false

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-*   text=auto
+*   text=false


### PR DESCRIPTION
Git converts CRLF/LF on checkout/commit which can lead to problems.
Tell Git not to mess with line endings, instead the dev's editor should handle them.