### PR TITLE
X1CA_001: Enables Seraphim and Nomads.

### DIFF
--- a/X1CA_Coop_001/X1CA_Coop_001_save.lua
+++ b/X1CA_Coop_001/X1CA_Coop_001_save.lua
@@ -7318,6 +7318,20 @@ Scenario = {
                                 Position = { 76.500000, 18.000000, 967.500000 },
                                 Orientation = { 0.000000, 3.141593, 0.000000 },
                             },
+                            ['SeraphimPlayer'] = {
+                                type = 'xsl0001',
+                                orders = '',
+                                platoon = '',
+                                Position = { 76.500000, 18.000000, 967.500000 },
+                                Orientation = { 0.000000, 3.141593, 0.000000 },
+                            },
+                            ['NomadsPlayer'] = {
+                                type = 'xnl0001',
+                                orders = '',
+                                platoon = '',
+                                Position = { 76.500000, 18.000000, 967.500000 },
+                                Orientation = { 0.000000, 3.141593, 0.000000 },
+                            }
                         },
                     },
                     ['WRECKAGE'] = GROUP {
@@ -21703,6 +21717,20 @@ Scenario = {
                                 Position = { 76.500000, 18.000000, 967.500000 },
                                 Orientation = { 0.000000, 3.141593, 0.000000 },
                             },
+                            ['SeraphimPlayer'] = {
+                                type = 'xsl0001',
+                                orders = '',
+                                platoon = '',
+                                Position = { 76.500000, 18.000000, 967.500000 },
+                                Orientation = { 0.000000, 3.141593, 0.000000 },
+                            },
+                            ['NomadsPlayer'] = {
+                                type = 'xnl0001',
+                                orders = '',
+                                platoon = '',
+                                Position = { 76.500000, 18.000000, 967.500000 },
+                                Orientation = { 0.000000, 3.141593, 0.000000 },
+                            }
                         },
                     },
                     ['WRECKAGE'] = GROUP {
@@ -21776,6 +21804,20 @@ Scenario = {
                                 Position = { 76.500000, 18.000000, 967.500000 },
                                 Orientation = { 0.000000, 3.141593, 0.000000 },
                             },
+                            ['SeraphimPlayer'] = {
+                                type = 'xsl0001',
+                                orders = '',
+                                platoon = '',
+                                Position = { 76.500000, 18.000000, 967.500000 },
+                                Orientation = { 0.000000, 3.141593, 0.000000 },
+                            },
+                            ['NomadsPlayer'] = {
+                                type = 'xnl0001',
+                                orders = '',
+                                platoon = '',
+                                Position = { 76.500000, 18.000000, 967.500000 },
+                                Orientation = { 0.000000, 3.141593, 0.000000 },
+                            }
                         },
                     },
                     ['WRECKAGE'] = GROUP {
@@ -26670,6 +26712,20 @@ Scenario = {
                             },
                             ['UEFPlayer'] = {
                                 type = 'uel0001',
+                                orders = '',
+                                platoon = '',
+                                Position = { 76.500000, 18.000000, 967.500000 },
+                                Orientation = { 0.000000, 3.141593, 0.000000 },
+                            },
+                            ['SeraphimPlayer'] = {
+                                type = 'xsl0001',
+                                orders = '',
+                                platoon = '',
+                                Position = { 76.500000, 18.000000, 967.500000 },
+                                Orientation = { 0.000000, 3.141593, 0.000000 },
+                            },
+                            ['NomadsPlayer'] = {
+                                type = 'xnl0001',
                                 orders = '',
                                 platoon = '',
                                 Position = { 76.500000, 18.000000, 967.500000 },

--- a/X1CA_Coop_001/X1CA_Coop_001_scenario.lua
+++ b/X1CA_Coop_001/X1CA_Coop_001_scenario.lua
@@ -18,6 +18,6 @@ ScenarioInfo = {
             },
             customprops = {
             },
-            factions = { {'uef', 'aeon', 'cybran'}, {'uef', 'aeon', 'cybran'}, {'uef', 'aeon', 'cybran'}, {'uef', 'aeon', 'cybran'} },
+            factions = { {'uef', 'aeon', 'cybran', 'seraphim', 'nomads'}, {'uef', 'aeon', 'cybran', 'seraphim', 'nomads'}, {'uef', 'aeon', 'cybran', 'seraphim', 'nomads'}, {'uef', 'aeon', 'cybran', 'seraphim', 'nomads'} },
         },
     }}


### PR DESCRIPTION
To enable Nomads selection, Nomads must be already installed using the following instructions: https://github.com/FAForever/NomadMissions/blob/master/README.md#how-do-i-play-the-missions-online

The mission should work regardless as to whether Nomads has been installed. 

Each of the new factions will follow the UEF primary and side quests. 