### PR TITLE
Fix interpretation of expansion timer value

### DIFF
--- a/FAF_Coop_Operation_Blockade/FAF_Coop_Operation_Blockade_script.lua
+++ b/FAF_Coop_Operation_Blockade/FAF_Coop_Operation_Blockade_script.lua
@@ -26,7 +26,7 @@ ScenarioInfo.Player3 = 5
 ScenarioInfo.Player4 = 6
 
 local Difficulty = ScenarioInfo.Options.Difficulty
-local ExpansionTimer = ScenarioInfo.Options.Expansion
+local ExpansionTimer = ScenarioInfo.Options.Expansion == 'true'
 
 local Player1 = ScenarioInfo.Player1
 local Seraphim = ScenarioInfo.Seraphim

--- a/FAF_Coop_Operation_Holy_Raid/FAF_Coop_Operation_Holy_Raid_script.lua
+++ b/FAF_Coop_Operation_Holy_Raid/FAF_Coop_Operation_Holy_Raid_script.lua
@@ -37,7 +37,7 @@ local Player3 = ScenarioInfo.Player3
 local Player4 = ScenarioInfo.Player4
 
 local AssignedObjectives = {}
-local ExpansionTimer = ScenarioInfo.Options.Expansion
+local ExpansionTimer = ScenarioInfo.Options.Expansion == 'true'
 
 local SkipNIS2 = false
 

--- a/FAF_Coop_Operation_Ioz_Shavoh_Kael/FAF_Coop_Operation_Ioz_Shavoh_Kael_script.lua
+++ b/FAF_Coop_Operation_Ioz_Shavoh_Kael/FAF_Coop_Operation_Ioz_Shavoh_Kael_script.lua
@@ -35,7 +35,7 @@ ScenarioInfo.Player3 = 7
 ScenarioInfo.Player4 = 8
 
 local Difficulty = ScenarioInfo.Options.Difficulty
-local ExpansionTimer = ScenarioInfo.Options.Expansion
+local ExpansionTimer = ScenarioInfo.Options.Expansion == 'true'
 
 local Player1 = ScenarioInfo.Player1
 local Player2 = ScenarioInfo.Player2

--- a/FAF_Coop_Operation_Tha_Atha_Aez/FAF_Coop_Operation_Tha_Atha_Aez_script.lua
+++ b/FAF_Coop_Operation_Tha_Atha_Aez/FAF_Coop_Operation_Tha_Atha_Aez_script.lua
@@ -49,7 +49,7 @@ local Player4 = ScenarioInfo.Player4
 local AssignedObjectives = {}
 
 local P2Offmaptriggered = false
-local ExpansionTimer = ScenarioInfo.Options.Expansion
+local ExpansionTimer = ScenarioInfo.Options.Expansion == 'true'
 
 local SupportBtimer = {7*60, 6*60, 5*60}  
 

--- a/FAF_Coop_Operation_Uhthe_Thuum_QAI/FAF_Coop_Operation_Uhthe_Thuum_QAI_script.lua
+++ b/FAF_Coop_Operation_Uhthe_Thuum_QAI/FAF_Coop_Operation_Uhthe_Thuum_QAI_script.lua
@@ -43,7 +43,7 @@ local Nodes = ScenarioInfo.Nodes
 local QAI = ScenarioInfo.QAI
 
 local TimedAttackP1 = {16*60, 14*60, 12*60}
-local ExpansionTimer = ScenarioInfo.Options.Expansion
+local ExpansionTimer = ScenarioInfo.Options.Expansion == 'true'
 
 local Debug = false
 local NIS1InitialDelay = 3

--- a/FAF_Coop_Operation_Yath_Aez/FAF_Coop_Operation_Yath_Aez_script.lua
+++ b/FAF_Coop_Operation_Yath_Aez/FAF_Coop_Operation_Yath_Aez_script.lua
@@ -42,7 +42,7 @@ local Player4 = ScenarioInfo.Player4
 local Debug = false
 
 local AssignedObjectives = {}
-local ExpansionTimer = ScenarioInfo.Options.Expansion
+local ExpansionTimer = ScenarioInfo.Options.Expansion == 'true'
 
 local NIS1InitialDelay = 3
 


### PR DESCRIPTION
The expansion timer is encoded as 'true' or 'false', which is of type string and not of type boolean. A string is always considered a truthy value in Lua. 

Some maps interpreted the value correct: `local ExpansionTimer = ScenarioInfo.Options.Expansion == 'true'`, others interpreted it as `local ExpansionTimer = ScenarioInfo.Options.Expansion` which is always true regardless of the lobby option.

@Shadowlorda1 this touches some of your maps.