### PR TITLE
Fix Aeon M2 objective SCCA_Coop_A02_script.lua

### DIFF
--- a/SCCA_Coop_A02/SCCA_Coop_A02_script.lua
+++ b/SCCA_Coop_A02/SCCA_Coop_A02_script.lua
@@ -677,7 +677,7 @@ function M2AssignSecretBaseObjective()
         end
     )
     --Sometimes this objective can trigger before the objective group is created since this is linked to when one of the naval base units is detected
-    while not(ScenarioInfo.M2ObjectiveGroup.AddObjective) do
+    while not(ScenarioInfo.M2ObjectiveGroup) do
         WaitSeconds(1)
     end
     ScenarioInfo.M2ObjectiveGroup:AddObjective(ScenarioInfo.M2P3Objective)

--- a/SCCA_Coop_A02/SCCA_Coop_A02_script.lua
+++ b/SCCA_Coop_A02/SCCA_Coop_A02_script.lua
@@ -676,6 +676,10 @@ function M2AssignSecretBaseObjective()
             end
         end
     )
+    --Sometimes this objective can trigger before the objective group is created since this is linked to when one of the naval base units is detected
+    while not(ScenarioInfo.M2ObjectiveGroup.AddObjective) do
+        WaitSeconds(1)
+    end
     ScenarioInfo.M2ObjectiveGroup:AddObjective(ScenarioInfo.M2P3Objective)
 
     ScenarioFramework.CreateTimerTrigger(M2CruiserWarning, 60) -- the cruiser will launch soon -- kill it


### PR DESCRIPTION
Fixes a bug that can break Aeon mission 2 if the stealthed base is detected too soon (causing the stealthed base objective to trigger first, which breaks the mission if mission 2 (of mission 2) hasn't triggered yet.

For further details see:
https://discord.com/channels/944679492293636116/944697747376853003/1132011694131007569