### PR TITLE
Aeon M2 - check if transport is dead

### DIFF
--- a/SCCA_Coop_A02/SCCA_Coop_A02_script.lua
+++ b/SCCA_Coop_A02/SCCA_Coop_A02_script.lua
@@ -1285,7 +1285,9 @@ function TransportAssault(platoon, landingLocation, patrolChain, airUnits)
         end
     else
         for _, v in transports do
-            aiBrain:AssignUnitsToPlatoon('TransportPool', {v}, 'Scout', 'None')
+            if not(v:IsDead()) then
+                aiBrain:AssignUnitsToPlatoon('TransportPool', {v}, 'Scout', 'None')
+            end
         end
     end
 end


### PR DESCRIPTION
A lua script error can arise if a transport is killed e.g. at the end of mission 2, as the code doesn't check if it is dead before trying to assign to a platoon.