### PR TITLE
Aeon M2 - Fix bug with map not expanding if attackers killed quickly

### DIFF
--- a/SCCA_Coop_A02/SCCA_Coop_A02_script.lua
+++ b/SCCA_Coop_A02/SCCA_Coop_A02_script.lua
@@ -891,6 +891,15 @@ function StartMission3()
         true
     )
 
+    if ScenarioInfo.M3Attackers then
+        --Redundancy for if the player has managed to kill all attackers before this triggers
+        local bAttacksAlreadyDead = true
+        for iUnit, oUnit in ScenarioInfo.M3Attackers do            
+            if not(oUnit:IsDead()) then bAttacksAlreadyDead = false break end
+        end        
+        if bAttacksAlreadyDead then M3DestroyCybranBases() end
+    end
+    
     -- If the player doesn't complete the objectives soon, remind him that it's important
     ScenarioFramework.CreateTimerTrigger(M3P2Reminder, 300)
     ScenarioFramework.CreateTimerTrigger(M3P4Reminder, 600)

--- a/SCCA_Coop_A02/SCCA_Coop_A02_script.lua
+++ b/SCCA_Coop_A02/SCCA_Coop_A02_script.lua
@@ -897,7 +897,7 @@ function StartMission3()
         for iUnit, oUnit in ScenarioInfo.M3Attackers do            
             if not(oUnit:IsDead()) then bAttacksAlreadyDead = false break end
         end        
-        if bAttacksAlreadyDead then M3DestroyCybranBases() end
+        if bAttacksAlreadyDead then ScenarioInfo.M3P1Objective:ManualResult(true) end
     end
     
     -- If the player doesn't complete the objectives soon, remind him that it's important


### PR DESCRIPTION
I had a game where the map wouldn't expand after the attackers were killed.  Adding in logs to this revealed all the M3Attackers were returning true for :IsDead(). Adding in the code to force the next mission objective to run if all attackers are dead resolved the issue and meant the map expanded.