### PR TITLE
Fix AI air attack - Aeon Mission 4

### DIFF
--- a/SCCA_Coop_A04/SCCA_Coop_A04_script.lua
+++ b/SCCA_Coop_A04/SCCA_Coop_A04_script.lua
@@ -830,7 +830,7 @@ function M2AttackFive()
 
     -- Air Attack NW
     WaitSeconds(37)
-    local navyCounter = GetNumOfHumanUnits(categories.NAVAL, 'West_Lake_Area')
+    local navyCounter = ScenarioFramework.GetNumOfHumanUnits(categories.NAVAL, 'West_Lake_Area')
     if navyCounter > 5 then
         local nwAirPlat = ScenarioUtils.CreateArmyGroupAsPlatoon('Cybran', 'M2A5_NW_Air_Naval_D' .. Difficulty, 'GrowthFormation')
         ScenarioFramework.PlatoonAttackChain(nwAirPlat, 'Cybran_M2_West_NW_Mainframe_Naval_Chain')


### PR DESCRIPTION
Previous reference was invalid, resulting in a lua error. E.g.:

WARNING: Error running lua script: ...ce\maps\scca_coop_a04.v0021\scca_coop_a04_script.lua(833): access to nonexistent global variable GetNumOfHumanUnits
         stack traceback:
         	[C]: in function `error'
         	...ata\faforever\gamedata\lua.nx2\lua\system\config.lua(54): in function <...ata\faforever\gamedata\lua.nx2\lua\system\config.lua:53>
         	...ce\maps\scca_coop_a04.v0021\scca_coop_a04_script.lua(833): in function `callback'
         	...\faforever\gamedata\lua.nx2\lua\scenariotriggers.lua(221): in function <...\faforever\gamedata\lua.nx2\lua\scenariotriggers.lua:203>

While the error doesn't break the mission, it impacts the air attacks that are sent.