### PR TITLE
Fix taunts in Aeon Mission 4

### DIFF
--- a/SCCA_Coop_A04/SCCA_Coop_A04_script.lua
+++ b/SCCA_Coop_A04/SCCA_Coop_A04_script.lua
@@ -662,10 +662,10 @@ function StartMission2()
 
     -- M2 Misc Triggers
     -- Taunts
-    ScenarioFramework.CreateTimerTrigger(PlayTaunt, 2 * 60)
-    ScenarioFramework.CreateTimerTrigger(PlayTaunt, 5 * 60)
-    ScenarioFramework.CreateTimerTrigger(PlayTaunt, 7 * 60)
-    ScenarioFramework.CreateTimerTrigger(PlayTaunt, 11 * 60)
+    ScenarioFramework.CreateTimerTrigger(PlayRandomTaunt, 2 * 60)
+    ScenarioFramework.CreateTimerTrigger(PlayRandomTaunt, 5 * 60)
+    ScenarioFramework.CreateTimerTrigger(PlayRandomTaunt, 7 * 60)
+    ScenarioFramework.CreateTimerTrigger(PlayRandomTaunt, 11 * 60)
 
     -- Objective reminder
     ScenarioFramework.CreateTimerTrigger(M2ObjectiveReminder, 300)


### PR DESCRIPTION
Fix the wrong references used for some of the taunts, which were resulting in a lua error:
WARNING: Error running lua script: ...ce\maps\scca_coop_a04.v0021\scca_coop_a04_script.lua(665): access to nonexistent global variable PlayTaunt
         stack traceback:
             [C]: in function `error'
             ...ata\faforever\gamedata\lua.nx2\lua\system\config.lua(54): in function <...ata\faforever\gamedata\lua.nx2\lua\system\config.lua:53>
             ...ce\maps\scca_coop_a04.v0021\scca_coop_a04_script.lua(665): in function `StartMission2'
             ...ce\maps\scca_coop_a04.v0021\scca_coop_a04_script.lua(606): in function <...ce\maps\scca_coop_a04.v0021\scca_coop_a04_script.lua:494>