### PR TITLE
FA M3 Red Dawn: Fix bug with 1st mission completion due to external factories

### DIFF
--- a/X1CA_Coop_003/X1CA_Coop_003_script.lua
+++ b/X1CA_Coop_003/X1CA_Coop_003_script.lua
@@ -498,7 +498,7 @@ function IntroMission1()
 end
 
 function StartMission1()
-    local units = ArmyBrains[Seraphim]:GetListOfUnits(categories.FACTORY * categories.STRUCTURE, false)
+    local units = ArmyBrains[Seraphim]:GetListOfUnits(categories.FACTORY * categories.STRUCTURE -categories.EXTERNALFACTORYUNIT, false)
 
     --------------------------------------------------
     -- Primary Objective 1 - Defeat Seraphim Naval Base


### PR DESCRIPTION
Following FAF changes introducing external factory units, these get included as part of the objective to be destroyed, but the objective doesn't complete when the parent unit is destroyed (presumably the OnKilled callback doesnt trigger for the external factory when it is removed due to the parent dying) Fix is to just exclude external factories from the list of units added to the objective.