### PR TITLE
Fix some incorrect Aeon briefing VO cue orders

### DIFF
--- a/SCCA_Coop_A01/SCCA_Coop_A01_Strings.lua
+++ b/SCCA_Coop_A01/SCCA_Coop_A01_Strings.lua
@@ -40,8 +40,8 @@ BriefingData = {
   movies = {'A01_B01.sfd', 'A01_B02.sfd', 'A01_B03.sfd'},
   voice = {
     {Cue = 'A01_B01', Bank = 'A01_VO'},
-    {Cue = 'A01_B02', Bank = 'A01_VO'},
     {Cue = 'A01_B03', Bank = 'A01_VO'},
+    {Cue = 'A01_B02', Bank = 'A01_VO'},
   },
   bgsound = {
     {Cue = 'A01_B01', Bank = 'Op_Briefing_Vanilla'},

--- a/SCCA_Coop_A02/SCCA_Coop_A02_strings.lua
+++ b/SCCA_Coop_A02/SCCA_Coop_A02_strings.lua
@@ -41,9 +41,9 @@ BriefingData = {
   },
   movies = {'A02_B01.sfd', 'A02_B02.sfd', 'A02_B03.sfd'},
   voice = {
-    {Cue = 'A02_B01', Bank = 'A02_VO'},
     {Cue = 'A02_B02', Bank = 'A02_VO'},
     {Cue = 'A02_B03', Bank = 'A02_VO'},
+    {Cue = 'A02_B01', Bank = 'A02_VO'},
   },
   bgsound = {
     {Cue = 'A02_B01', Bank = 'Op_Briefing_Vanilla'},

--- a/SCCA_Coop_A03/SCCA_Coop_A03_strings.lua
+++ b/SCCA_Coop_A03/SCCA_Coop_A03_strings.lua
@@ -37,9 +37,9 @@ BriefingData = {
   },
   movies = {'A03_B01.sfd', 'A03_B02.sfd', 'A03_B03.sfd'},
   voice = {
-    {Cue = 'A03_B01', Bank = 'A03_VO'},
     {Cue = 'A03_B02', Bank = 'A03_VO'},
     {Cue = 'A03_B03', Bank = 'A03_VO'},
+    {Cue = 'A03_B01', Bank = 'A03_VO'},
   },
   bgsound = {
     {Cue = 'A03_B01', Bank = 'Op_Briefing_Vanilla'},

--- a/SCCA_Coop_A06/SCCA_Coop_A06_strings.lua
+++ b/SCCA_Coop_A06/SCCA_Coop_A06_strings.lua
@@ -35,9 +35,9 @@ BriefingData = {
   },
   movies = {'A06_B01.sfd', 'A06_B02.sfd', 'A06_B03.sfd'},
   voice = {
-    {Cue = 'A06_B01', Bank = 'A06_VO'},
     {Cue = 'A06_B02', Bank = 'A06_VO'},
     {Cue = 'A06_B03', Bank = 'A06_VO'},
+    {Cue = 'A06_B01', Bank = 'A06_VO'},
   },
   bgsound = {
     {Cue = 'A06_B01', Bank = 'Op_Briefing_Vanilla'},


### PR DESCRIPTION
Fixes some incorrect briefing cue orders for VO in certain Aeon missions.

Specifically:
AEON M1 - Voice cue order fixed
AEON M2 - Voice cue order fixed
AEON M3 - Voice cue order fixed
AEON M6 - Voice cue order fixed