### PR TITLE
Cybran M6 - Bugfix if units destroyed

### DIFF
--- a/SCCA_Coop_R06/SCCA_Coop_R06_script.lua
+++ b/SCCA_Coop_R06/SCCA_Coop_R06_script.lua
@@ -1138,7 +1138,7 @@ function StartMission3()
     IssueDive({ScenarioInfo.Atlantis})
     for i = 1, 9 do
         IssuePatrol({ScenarioInfo.Atlantis}, ScenarioUtils.MarkerToPosition('AtlantisAttack' .. i))
-        ScenarioInfo.AtlantisBoats:Patrol(ScenarioUtils.MarkerToPosition('AtlantisAttack' .. i))
+        if not(IsDestroyed(ScenarioInfo.AtlantisBoats)) then ScenarioInfo.AtlantisBoats:Patrol(ScenarioUtils.MarkerToPosition('AtlantisAttack' .. i)) end
     end
     ScenarioFramework.CreateUnitNearTypeTrigger(StartAtlantisAI, ScenarioInfo.Atlantis, ArmyBrains[Player1], categories.ALLUNITS, 80)
 


### PR DESCRIPTION
Game is impossible to complete if units are destroyed as the script fails at this line and doesn't create the trigger for black sun being captured as a result.