### PR TITLE
Cybran M4 fix where player is quicker than intro

### DIFF
--- a/SCCA_Coop_R04/SCCA_Coop_R04_script.lua
+++ b/SCCA_Coop_R04/SCCA_Coop_R04_script.lua
@@ -914,55 +914,58 @@ function IntroMission3()
 end
 
 function StartMission3()
-    ScenarioFramework.Dialogue(OpStrings.C04_M03_020, nil, true)
-
-    -----------------------------------
-    -- Primary Objective - Capture Node
-    -----------------------------------
-    ScenarioInfo.M3P1Objective = Objectives.Basic(
-        'primary',
-        'incomplete',
-        OpStrings.M3P1Text,
-        OpStrings.M3P1Detail,
-        Objectives.GetActionIcon('capture'),
-        {
-            Units = {ScenarioInfo.Node3},
-            MarkUnits = true,
-        }
-    )
-
-    -----------------------------------
-    -- Primary Objective - Capture Node
-    -----------------------------------
-    ScenarioInfo.M3P2Objective = Objectives.Basic(
-        'primary',
-        'incomplete',
-        OpStrings.M3P2Text,
-        OpStrings.M3P2Detail,
-        Objectives.GetActionIcon('capture'),
-        {
-            Units = {ScenarioInfo.Node4},
-            MarkUnits = true,
-        }
-    )
-
-    ----------------------------------------
-    -- Primary Objective - Protect Mainframe
-    ----------------------------------------
-    ScenarioInfo.M3P4Objective = Objectives.Basic(
-        'primary',
-        'incomplete',
-        OpStrings.M3P4Text,
-        OpStrings.M3P4Detail,
-        Objectives.GetActionIcon('protect'),
-        {
-            Areas = {'Aeon_Base_M3'},
-            ShowFaction = 'Aeon',
-        }
-    )
-
-    -- Reminder
-    ScenarioFramework.CreateTimerTrigger(M3P1Reminder, 900)
+    if not(ScenarioInfo.M3P1Started == true) then
+        ScenarioInfo.M3P1Started = true
+        ScenarioFramework.Dialogue(OpStrings.C04_M03_020, nil, true)
+    
+        -----------------------------------
+        -- Primary Objective - Capture Node
+        -----------------------------------
+        ScenarioInfo.M3P1Objective = Objectives.Basic(
+            'primary',
+            'incomplete',
+            OpStrings.M3P1Text,
+            OpStrings.M3P1Detail,
+            Objectives.GetActionIcon('capture'),
+            {
+                Units = {ScenarioInfo.Node3},
+                MarkUnits = true,
+            }
+        )
+    
+        -----------------------------------
+        -- Primary Objective - Capture Node
+        -----------------------------------
+        ScenarioInfo.M3P2Objective = Objectives.Basic(
+            'primary',
+            'incomplete',
+            OpStrings.M3P2Text,
+            OpStrings.M3P2Detail,
+            Objectives.GetActionIcon('capture'),
+            {
+                Units = {ScenarioInfo.Node4},
+                MarkUnits = true,
+            }
+        )
+    
+        ----------------------------------------
+        -- Primary Objective - Protect Mainframe
+        ----------------------------------------
+        ScenarioInfo.M3P4Objective = Objectives.Basic(
+            'primary',
+            'incomplete',
+            OpStrings.M3P4Text,
+            OpStrings.M3P4Detail,
+            Objectives.GetActionIcon('protect'),
+            {
+                Areas = {'Aeon_Base_M3'},
+                ShowFaction = 'Aeon',
+            }
+        )
+    
+        -- Reminder
+        ScenarioFramework.CreateTimerTrigger(M3P1Reminder, 900)
+    end
 end
 
 function M3BaseDamaged(unit)
@@ -1065,6 +1068,7 @@ end
 
 -- Northwest node
 function Node3Captured(newNodeHandle)
+    if not(ScenarioInfo.M3P1Started) then StartMission3() end
     ScenarioInfo.Node3 = newNodeHandle
     ScenarioInfo.Node3Captured = true
     ScenarioFramework.CreateUnitDeathTrigger(NodeDied, ScenarioInfo.Node3)
@@ -1092,6 +1096,7 @@ function Node3Captured(newNodeHandle)
 end
 
 function Node4Captured(newNodeHandle)
+    if not(ScenarioInfo.M3P1Started) then StartMission3() end
     ScenarioInfo.Node4 = newNodeHandle
     ScenarioInfo.Node4Captured = true
     ScenarioFramework.CreateUnitDeathTrigger(NodeDied, ScenarioInfo.Node4)

--- a/SCCA_Coop_R04/SCCA_Coop_R04_script.lua
+++ b/SCCA_Coop_R04/SCCA_Coop_R04_script.lua
@@ -914,58 +914,59 @@ function IntroMission3()
 end
 
 function StartMission3()
-    if not(ScenarioInfo.M3P1Started == true) then
-        ScenarioInfo.M3P1Started = true
-        ScenarioFramework.Dialogue(OpStrings.C04_M03_020, nil, true)
-    
-        -----------------------------------
-        -- Primary Objective - Capture Node
-        -----------------------------------
-        ScenarioInfo.M3P1Objective = Objectives.Basic(
-            'primary',
-            'incomplete',
-            OpStrings.M3P1Text,
-            OpStrings.M3P1Detail,
-            Objectives.GetActionIcon('capture'),
-            {
-                Units = {ScenarioInfo.Node3},
-                MarkUnits = true,
-            }
-        )
-    
-        -----------------------------------
-        -- Primary Objective - Capture Node
-        -----------------------------------
-        ScenarioInfo.M3P2Objective = Objectives.Basic(
-            'primary',
-            'incomplete',
-            OpStrings.M3P2Text,
-            OpStrings.M3P2Detail,
-            Objectives.GetActionIcon('capture'),
-            {
-                Units = {ScenarioInfo.Node4},
-                MarkUnits = true,
-            }
-        )
-    
-        ----------------------------------------
-        -- Primary Objective - Protect Mainframe
-        ----------------------------------------
-        ScenarioInfo.M3P4Objective = Objectives.Basic(
-            'primary',
-            'incomplete',
-            OpStrings.M3P4Text,
-            OpStrings.M3P4Detail,
-            Objectives.GetActionIcon('protect'),
-            {
-                Areas = {'Aeon_Base_M3'},
-                ShowFaction = 'Aeon',
-            }
-        )
-    
-        -- Reminder
-        ScenarioFramework.CreateTimerTrigger(M3P1Reminder, 900)
+    if ScenarioInfo.M3P1Started == true then
+        return
     end
+    ScenarioInfo.M3P1Started = true
+    ScenarioFramework.Dialogue(OpStrings.C04_M03_020, nil, true)
+
+    -----------------------------------
+    -- Primary Objective - Capture Node
+    -----------------------------------
+    ScenarioInfo.M3P1Objective = Objectives.Basic(
+        'primary',
+        'incomplete',
+        OpStrings.M3P1Text,
+        OpStrings.M3P1Detail,
+        Objectives.GetActionIcon('capture'),
+        {
+            Units = {ScenarioInfo.Node3},
+            MarkUnits = true,
+        }
+    )
+
+    -----------------------------------
+    -- Primary Objective - Capture Node
+    -----------------------------------
+    ScenarioInfo.M3P2Objective = Objectives.Basic(
+        'primary',
+        'incomplete',
+        OpStrings.M3P2Text,
+        OpStrings.M3P2Detail,
+        Objectives.GetActionIcon('capture'),
+        {
+            Units = {ScenarioInfo.Node4},
+            MarkUnits = true,
+        }
+    )
+
+    ----------------------------------------
+    -- Primary Objective - Protect Mainframe
+    ----------------------------------------
+    ScenarioInfo.M3P4Objective = Objectives.Basic(
+        'primary',
+        'incomplete',
+        OpStrings.M3P4Text,
+        OpStrings.M3P4Detail,
+        Objectives.GetActionIcon('protect'),
+        {
+            Areas = {'Aeon_Base_M3'},
+            ShowFaction = 'Aeon',
+        }
+    )
+
+    -- Reminder
+    ScenarioFramework.CreateTimerTrigger(M3P1Reminder, 900)    
 end
 
 function M3BaseDamaged(unit)


### PR DESCRIPTION
Adds redundancy for an issue/error message that can occur if the player is able to capture one of the nodes before the video briefing has completed