### PR TITLE
Aeon M4 fix bug with missing transport platoon

### DIFF
--- a/SCCA_Coop_A04/SCCA_Coop_A04_script.lua
+++ b/SCCA_Coop_A04/SCCA_Coop_A04_script.lua
@@ -888,7 +888,9 @@ function M2EastLandAssault(units, transports)
     end
     if aiBrain:PlatoonExists(transports) then
         transports:MoveToLocation(ScenarioUtils.MarkerToPosition('Cybran_East_Transport_Return'), false)
-        aiBrain:AssignUnitsToPlatoon('TransportPool', transports:GetPlatoonUnits(), 'Scout', 'None')
+        if aiBrain:PlatoonExists('TransportPool') then
+            aiBrain:AssignUnitsToPlatoon('TransportPool', transports:GetPlatoonUnits(), 'Scout', 'None')
+        end
     end
     if aiBrain:PlatoonExists(units) then
         units:AggressiveMoveToLocation(ScenarioUtils.MarkerToPosition('Mainframe_Marker'))


### PR DESCRIPTION
Fixes error when game tries assigning units to a platoon that doesnt exist