### PR TITLE
Fix Aeon M4 bug with incorrect platoon reference

### DIFF
--- a/SCCA_Coop_A04/SCCA_Coop_A04_script.lua
+++ b/SCCA_Coop_A04/SCCA_Coop_A04_script.lua
@@ -888,8 +888,9 @@ function M2EastLandAssault(units, transports)
     end
     if aiBrain:PlatoonExists(transports) then
         transports:MoveToLocation(ScenarioUtils.MarkerToPosition('Cybran_East_Transport_Return'), false)
-        if aiBrain:PlatoonExists('TransportPool') then
-            aiBrain:AssignUnitsToPlatoon('TransportPool', transports:GetPlatoonUnits(), 'Scout', 'None')
+        local TransportPool = aiBrain:GetPlatoonUniquelyNamed('TransportPool')
+        if aiBrain:PlatoonExists(TransportPool) then
+            aiBrain:AssignUnitsToPlatoon(TransportPool, transports:GetPlatoonUnits(), 'Scout', 'None')
         end
     end
     if aiBrain:PlatoonExists(units) then

--- a/SCCA_Coop_A04/SCCA_Coop_A04_script.lua
+++ b/SCCA_Coop_A04/SCCA_Coop_A04_script.lua
@@ -890,7 +890,20 @@ function M2EastLandAssault(units, transports)
         transports:MoveToLocation(ScenarioUtils.MarkerToPosition('Cybran_East_Transport_Return'), false)
         local TransportPool = aiBrain:GetPlatoonUniquelyNamed('TransportPool')
         if aiBrain:PlatoonExists(TransportPool) then
-            aiBrain:AssignUnitsToPlatoon(TransportPool, transports:GetPlatoonUnits(), 'Scout', 'None')
+            local tValidPlatoonUnits = {}
+            local tAllUnits = transports:GetPlatoonUnits()
+            local bHaveValidUnits = false
+            if tAllUnits[1] then
+                for iUnit, oUnit in tAllUnits do                    
+                    if not(oUnit.Dead) then                        
+                        table.insert(tValidPlatoonUnits, oUnit)
+                        bHaveValidUnits = true
+                    end
+                end
+            end            
+            if bHaveValidUnits then
+                aiBrain:AssignUnitsToPlatoon(TransportPool, tValidPlatoonUnits, 'Scout', 'None')
+            end
         end
     end
     if aiBrain:PlatoonExists(units) then


### PR DESCRIPTION
Fixes a bug caused by a reference to a string instead of a platoon

Error message given prior to this change:
WARNING: Error running lua script: ...alliance\maps\scca_coop_a04\scca_coop_a04_script.lua(891): Expected a game object. (Did you call with '.' instead of ':'?)
         stack traceback:
         	[C]: in function `PlatoonExists'
         	...alliance\maps\scca_coop_a04\scca_coop_a04_script.lua(891): in function <...alliance\maps\scca_coop_a04\scca_coop_a04_script.lua:880>
