### PR TITLE
UEF M4 Fix issue if engineer killed before teleport

### DIFF
--- a/SCCA_Coop_E04/SCCA_Coop_E04_script.lua
+++ b/SCCA_Coop_E04/SCCA_Coop_E04_script.lua
@@ -1218,7 +1218,7 @@ end
 function M3OnEngineerEscaped(units)
 
     for k, eng in units do
-        if not eng.GateStarted then
+        if not eng.GateStarted and not(eng.Dead) then            
             eng.GateStarted = true
             M3FleeingEngineersEscapedCount = M3FleeingEngineersEscapedCount + 1
             LOG('debugMatt:Engineer Escaped, count: '..M3FleeingEngineersEscapedCount)


### PR DESCRIPTION
Fixes an issue where the engineer can be given the order to teleport but when the logic triggers the engineer is already dead.

Error that prompted the change:
WARNING: Error running lua script: ...faforever\gamedata\lua.nx2\lua\scenarioframework.lua(921): Game object has been destroyed
         stack traceback:
         	[C]: in function `GetOrientation'
         	...faforever\gamedata\lua.nx2\lua\scenarioframework.lua(921): in function `FakeTeleportUnit'
         	...alliance\maps\scca_coop_e04\scca_coop_e04_script.lua(1227): in function `callbackFunction'
         	...\faforever\gamedata\lua.nx2\lua\scenariotriggers.lua(676): in function <...\faforever\gamedata\lua.nx2\lua\scenariotriggers.lua:618>