### PR TITLE
UEF M5 Fix SMD check bug

### DIFF
--- a/SCCA_Coop_E05/SCCA_Coop_E05_script.lua
+++ b/SCCA_Coop_E05/SCCA_Coop_E05_script.lua
@@ -480,13 +480,15 @@ function SiloAmmoThread(callback, areaName)
     local cats = categories.SILO * categories.ANTIMISSILE
 
     while not hasAmmo do
-        local units = ScenarioFramework.GetListOfHumanUnits(cats, rect)
+        --local units = ScenarioFramework.GetListOfHumanUnits(cats, rect)
         local units = GetUnitsInRect(rect)
-        for k,v in units do
-            if not v.Dead and v:GetTacticalSiloAmmoCount() > 0 then
-                if not hasAmmo then
-                    hasAmmo = true
-                    callback()
+        if units[1] then
+            for k,v in units do
+                if not v.Dead and v.GetTacticalSiloAmmoCount and EntityCategoryContains(cats, v.UnitId) and v:GetTacticalSiloAmmoCount() > 0 then
+                    if not hasAmmo then
+                        hasAmmo = true
+                        callback()
+                    end
                 end
             end
         end


### PR DESCRIPTION
Fix bug when checking for units with SMD:
-Previous code would error out if no units in the rectangle -Also included unnecessary logic to get local units before replacing local units immediately after -also didn't appear to actually check for the categories wanted

Error that prompted this change:
WARNING: Error running lua script: ...alliance\maps\scca_coop_e05\scca_coop_e05_script.lua(485): attempt to loop over local `units' (a nil value)
         stack traceback:
         	...alliance\maps\scca_coop_e05\scca_coop_e05_script.lua(485): in function <...alliance\maps\scca_coop_e05\scca_coop_e05_script.lua:477>
