### PR TITLE
Use Aeon units in Selene's CZAR

### DIFF
--- a/X1CA_Coop_002/X1CA_Coop_002_save.lua
+++ b/X1CA_Coop_002/X1CA_Coop_002_save.lua
@@ -23573,14 +23573,14 @@ Scenario = {
                                                 Orientation = { 0.000000, 0.000000, 0.000000 },
                                             },
                                             ['UNIT_4519'] = {
-                                                type = 'ura0103',
+                                                type = 'uaa0103',
                                                 orders = '',
                                                 platoon = '',
                                                 Position = { 937.000000, 21.675781, 198.500000 },
                                                 Orientation = { 0.000000, 0.000000, 0.000000 },
                                             },
                                             ['UNIT_4520'] = {
-                                                type = 'ura0203',
+                                                type = 'uaa0203',
                                                 orders = '',
                                                 platoon = '',
                                                 Position = { 939.500000, 21.638672, 198.500000 },


### PR DESCRIPTION
For some reason the bombers are gunships in Selene's CZAR were Cybran, This changes them to Aeon