### PR TITLE
Adds missing expansion timer checks.

### DIFF
--- a/FAF_Coop_Fort_Clarke_Assault/FAF_Coop_Fort_Clarke_Assault_script.lua
+++ b/FAF_Coop_Fort_Clarke_Assault/FAF_Coop_Fort_Clarke_Assault_script.lua
@@ -855,8 +855,10 @@ function StartMission2()
     ScenarioFramework.CreateTimerTrigger(M2UnlockSniperBots, 120)
 
     -- Expand map even if objective isn't finished yet
-    local M2MapExpandDelay = {20*60, 15*60, 10*60}
-    ScenarioFramework.CreateTimerTrigger(EndMission2, M2MapExpandDelay[Difficulty])
+    if ExpansionTimer then
+        local M2MapExpandDelay = {20*60, 15*60, 10*60}
+        ScenarioFramework.CreateTimerTrigger(EndMission2, M2MapExpandDelay[Difficulty])
+    end
 end
 
 function M2InitialAttack()

--- a/FAF_Coop_Havens_Invasion/FAF_Coop_Havens_Invasion_script.lua
+++ b/FAF_Coop_Havens_Invasion/FAF_Coop_Havens_Invasion_script.lua
@@ -30,6 +30,7 @@ local Seraphim = ScenarioInfo.Seraphim
 local Civilian = ScenarioInfo.Civilian
 
 local Difficulty = ScenarioInfo.Options.Difficulty
+local ExpansionTimer = ScenarioInfo.Options.Expansion == 'true'
 local AssignedObjectives = {}
 
 local LeaderFaction
@@ -275,8 +276,11 @@ function StartMission1()
     -- Evac the trucks after 5 minues
     ScenarioFramework.CreateTimerTrigger(M1EvacTrucks, 5*60)
 
-    -- Expand the map after 6 minues
-    ScenarioFramework.CreateTimerTrigger(M1MapExpand, 6*60)
+    -- Map expand only if option is enabled.
+    if ExpansionTimer then
+        local M1MapExpandDelay = {12*60, 9*60, 6*60}
+        ScenarioFramework.CreateTimerTrigger(IntroMission2, M1MapExpandDelay[Difficulty])
+    end
 end
 
 function MissionNameAnnouncement()
@@ -356,10 +360,6 @@ function M1TruckEscaped(unit)
     if ScenarioInfo.M1B1.Active then
         ScenarioInfo.M1B1:ManualResult(false)
     end
-end
-
-function M1MapExpand()
-    IntroMission2()
 end
 
 ------------

--- a/FAF_Coop_Operation_Holy_Raid/FAF_Coop_Operation_Holy_Raid_script.lua
+++ b/FAF_Coop_Operation_Holy_Raid/FAF_Coop_Operation_Holy_Raid_script.lua
@@ -267,14 +267,9 @@ function StartMission1()
         end
     )
 
-    WaitSeconds(180)
-    ForkThread(AttackCheck)  
-end
-
-function AttackCheck()
-    
-    if ScenarioInfo.M1P1.Active then
-        ScenarioInfo.M1P1:ManualResult(true)   
+    if ExpansionTimer then
+        local M1MapExpandDelay = {7*60, 5*60, 3*60}
+        ScenarioFramework.CreateTimerTrigger(StartIntroP2, M1MapExpandDelay[Difficulty])
     end
 end
 

--- a/FAF_Coop_Theta_Civilian_Rescue/FAF_Coop_Theta_Civilian_Rescue_script.lua
+++ b/FAF_Coop_Theta_Civilian_Rescue/FAF_Coop_Theta_Civilian_Rescue_script.lua
@@ -42,6 +42,7 @@ local Player4 = ScenarioInfo.Player4
 
 local AssignedObjectives = {}
 local Difficulty = ScenarioInfo.Options.Difficulty
+local ExpansionTimer = ScenarioInfo.Options.Expansion == 'true'
 
 local M1MapExpandDelay = {30*60, 25*60, 20*60} --30*60, 25*60, 20*60
 local M2SpawnMonkeylordTime = {60*60, 45*60, 35*60} --60*60, 45*60, 35*60
@@ -252,7 +253,9 @@ function StartMission1()
     table.insert(AssignedObjectives, ScenarioInfo.M1P1)
 
     -- Expand map even if objective isn't finished yet
-    ScenarioFramework.CreateTimerTrigger(PrematureMission2, M1MapExpandDelay[Difficulty])
+    if ExpansionTimer then
+        ScenarioFramework.CreateTimerTrigger(PrematureMission2, M1MapExpandDelay[Difficulty])
+    end
     
     ----------------------------------------
     -- Secondary Objective 1 - Destroy Base


### PR DESCRIPTION
In some missions the Map Expansion setting (accessible in the lobby settings) is not respected. This change update missions to make sure that setting is respected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an expansion timer option to several cooperative scenarios.
  - Map expansion can now be enabled or skipped based on the selected scenario setting.
  - Expansion timing now varies by difficulty in supported missions.

- **Bug Fixes**
  - Prevented map expansion from triggering prematurely when the expansion option is disabled.
  - Updated mission transitions to follow the configured expansion timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->